### PR TITLE
Prevent crash on exit (on macOS)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,8 @@ int main(int argc, char *argv[])
 		a.setOrganizationName(WMIT_ORG);
 		QSettings::setDefaultFormat(QSettings::IniFormat);
 
-		MainWindow w;
+		QWZM model; // must be destructed *after* all of MainWindow's children to prevent a crash on exit (on some platforms)
+		MainWindow w(model);
 		w.show();
 
 		if (argc == 2)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -87,7 +87,7 @@ class MainWindow : public QMainWindow
 	Q_OBJECT
 
 public:
-	MainWindow(QWidget *parent = nullptr);
+	MainWindow(QWZM &model, QWidget *parent = nullptr);
 	~MainWindow();
 
 	void clear();
@@ -158,7 +158,7 @@ private:
 	QAction *m_actionEnableTangentInShaders;
 	QString m_pathImport, m_pathExport;
 
-	QWZM m_model;
+	QWZM *m_model;
 	ModelInfo m_modelinfo;
 	QString m_pathvert, m_pathfrag;
 


### PR DESCRIPTION
The `QWZM` model must be destructed *after* all of MainWindow's children, otherwise there may be a crash within `QtGLView::~QtGLView()`.

Simple workaround to ensure destruction order.