### PR TITLE
Fix some MSVC warnings in Pie_t.hpp

### DIFF
--- a/src/formats/Pie.h
+++ b/src/formats/Pie.h
@@ -181,10 +181,10 @@ public:
 	virtual bool read(std::istream& in, PieCaps& caps);
 	virtual void write(std::ostream& out, const PieCaps& caps) const;
 
-	int points() const;
-	int normals() const;
-	int polygons() const;
-	int connectors() const;
+	size_t points() const;
+	size_t normals() const;
+	size_t polygons() const;
+	size_t connectors() const;
 
 	bool isValid() const;
 
@@ -214,7 +214,7 @@ public:
 	virtual bool read(std::istream& in);
 	virtual void write(std::ostream& out, const PieCaps* piecaps = nullptr) const;
 
-	unsigned levels() const;
+	size_t levels() const;
 	virtual unsigned getType() const;
 
 	bool isValid() const;

--- a/src/formats/Pie_t.hpp
+++ b/src/formats/Pie_t.hpp
@@ -257,25 +257,25 @@ void APieLevel< V, P, C>::write(std::ostream &out, const PieCaps &caps) const
 }
 
 template<typename V, typename P, typename C>
-int APieLevel< V, P, C>::points() const
+size_t APieLevel< V, P, C>::points() const
 {
 	return m_points.size();
 }
 
 template<typename V, typename P, typename C>
-int APieLevel< V, P, C>::normals() const
+size_t APieLevel< V, P, C>::normals() const
 {
 	return m_normals.size();
 }
 
 template<typename V, typename P, typename C>
-int APieLevel< V, P, C>::polygons() const
+size_t APieLevel< V, P, C>::polygons() const
 {
 	return m_polygons.size();
 }
 
 template<typename V, typename P, typename C>
-int APieLevel< V, P, C>::connectors() const
+size_t APieLevel< V, P, C>::connectors() const
 {
 	return m_connectors.size();
 }
@@ -637,7 +637,7 @@ void APieModel<L>::write(std::ostream& out, const PieCaps *piecaps) const
 }
 
 template <typename L>
-unsigned APieModel<L>::levels() const
+size_t APieModel<L>::levels() const
 {
 	return m_levels.size();
 }


### PR DESCRIPTION
```
warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
```