### PR TITLE
Changes for 0.6.11 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ set( wmit_HEADERS
 	src/widgets/QtGLView.h
 	src/ui/ExportDialog.h
 	src/ui/ImportDialog.h
+	src/ui/LightColorWidget.h
 	src/ui/LightColorDock.h
 	src/ui/MainWindow.h
 	src/ui/TexConfigDialog.h
@@ -156,6 +157,7 @@ set( wmit_SRCS
 	src/formats/Mesh.cpp
 	src/ui/UVEditor.cpp
 	src/ui/TransformDock.cpp
+	src/ui/LightColorWidget.cpp
 	src/ui/LightColorDock.cpp
 	src/ui/MainWindow.cpp
 	src/ui/ImportDialog.cpp
@@ -176,6 +178,7 @@ set( wmit_SRCS
 set( wmit_UIS
 	src/ui/UVEditor.ui
 	src/ui/TransformDock.ui
+	src/ui/LightColorWidget.ui
 	src/ui/LightColorDock.ui
 	src/ui/MainWindow.ui
 	src/ui/ImportDialog.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set( wmit_HEADERS
 	src/wmit.h
 	src/basic/IGLShaderManager.h
 	src/basic/IGLShaderRenderable.h
+	src/basic/WZLight.h
 	src/ui/TextureDialog.h
 	src/Generic.h
 	src/Util.h
@@ -161,6 +162,7 @@ set( wmit_SRCS
 	src/main.cpp
 	src/Generic.cpp
 	src/basic/GLTexture.cpp
+	src/basic/WZLight.cpp
 	src/widgets/QWZM.cpp
 	src/widgets/QtGLView.cpp
 	src/ui/TextureDialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ set( wmit_HEADERS
 	src/widgets/QtGLView.h
 	src/ui/ExportDialog.h
 	src/ui/ImportDialog.h
+	src/ui/LightColorDock.h
 	src/ui/MainWindow.h
 	src/ui/TexConfigDialog.h
 	src/ui/TransformDock.h
@@ -155,6 +156,7 @@ set( wmit_SRCS
 	src/formats/Mesh.cpp
 	src/ui/UVEditor.cpp
 	src/ui/TransformDock.cpp
+	src/ui/LightColorDock.cpp
 	src/ui/MainWindow.cpp
 	src/ui/ImportDialog.cpp
 	src/ui/ExportDialog.cpp
@@ -174,6 +176,7 @@ set( wmit_SRCS
 set( wmit_UIS
 	src/ui/UVEditor.ui
 	src/ui/TransformDock.ui
+	src/ui/LightColorDock.ui
 	src/ui/MainWindow.ui
 	src/ui/ImportDialog.ui
 	src/ui/ExportDialog.ui

--- a/data/shaders/wz33_tcmask.frag
+++ b/data/shaders/wz33_tcmask.frag
@@ -1,0 +1,110 @@
+// Version directive is set by Warzone when loading the shader
+// (This shader supports GLSL 1.20 - 1.50 core.)
+
+//#pragma debug(on)
+
+uniform sampler2D Texture; // diffuse
+uniform sampler2D TextureTcmask; // tcmask
+uniform sampler2D TextureNormal; // normal map
+uniform sampler2D TextureSpecular; // specular map
+uniform vec4 colour;
+uniform vec4 teamcolour; // the team colour of the model
+uniform int tcmask; // whether a tcmask texture exists for the model
+uniform int normalmap; // whether a normal map exists for the model
+uniform int specularmap; // whether a specular map exists for the model
+uniform bool ecmEffect; // whether ECM special effect is enabled
+uniform bool alphaTest;
+uniform float graphicsCycle; // a periodically cycling value for special effects
+
+uniform vec4 sceneColor;
+uniform vec4 ambient;
+uniform vec4 diffuse;
+uniform vec4 specular;
+
+uniform int fogEnabled; // whether fog is enabled
+uniform float fogEnd;
+uniform float fogStart;
+uniform vec4 fogColor;
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+in float vertexDistance;
+in vec3 normal, lightDir, eyeVec;
+in vec2 texCoord;
+#else
+varying float vertexDistance;
+varying vec3 normal, lightDir, eyeVec;
+varying vec2 texCoord;
+#endif
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+out vec4 FragColor;
+#else
+// Uses gl_FragColor
+#endif
+
+void main()
+{
+	vec4 light = sceneColor * vec4(.2, .2, .2, 1.) + ambient;
+	vec3 N = normalize(normal);
+	vec3 L = normalize(lightDir);
+	float lambertTerm = dot(N, L);
+	if (lambertTerm > 0.0)
+	{
+		light += diffuse * lambertTerm;
+		vec3 E = normalize(eyeVec);
+		vec3 R = reflect(-L, N);
+		float s = pow(max(dot(R, E), 0.0), 10.0); // 10 is an arbitrary value for now
+		light += specular * s;
+	}
+
+	// Get color from texture unit 0, merge with lighting
+	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+	vec4 texColour = texture(Texture, texCoord) * light;
+	#else
+	vec4 texColour = texture2D(Texture, texCoord) * light;
+	#endif
+
+	vec4 fragColour;
+	if (tcmask == 1)
+	{
+		// Get tcmask information from texture unit 1
+		#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+		vec4 mask = texture(TextureTcmask, texCoord);
+		#else
+		vec4 mask = texture2D(TextureTcmask, texCoord);
+		#endif
+
+		// Apply color using grain merge with tcmask
+		fragColour = (texColour + (teamcolour - 0.5) * mask.a) * colour;
+	}
+	else
+	{
+		fragColour = texColour * colour;
+	}
+
+	if (ecmEffect)
+	{
+		fragColour.a = 0.66 + 0.66 * graphicsCycle;
+	}
+
+	if (fogEnabled > 0)
+	{
+		// Calculate linear fog
+		float fogFactor = (fogEnd - vertexDistance) / (fogEnd - fogStart);
+		fogFactor = clamp(fogFactor, 0.0, 1.0);
+
+		// Return fragment color
+		fragColour = mix(fogColor, fragColour, fogFactor);
+	}
+
+	if (alphaTest && (fragColour.a <= 0.001))
+	{
+		discard;
+	}
+
+	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+	FragColor = fragColour;
+	#else
+	gl_FragColor = fragColour;
+	#endif
+}

--- a/data/shaders/wz33_tcmask.vert
+++ b/data/shaders/wz33_tcmask.vert
@@ -1,0 +1,58 @@
+// Version directive is set by Warzone when loading the shader
+// (This shader supports GLSL 1.20 - 1.50 core.)
+
+//#pragma debug(on)
+
+uniform float stretch;
+uniform mat4 ModelViewMatrix;
+uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 NormalMatrix;
+
+uniform vec4 lightPosition;
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+in vec4 vertex;
+in vec3 vertexNormal;
+in vec2 vertexTexCoord;
+#else
+attribute vec4 vertex;
+attribute vec3 vertexNormal;
+attribute vec2 vertexTexCoord;
+#endif
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+out float vertexDistance;
+out vec3 normal, lightDir, eyeVec;
+out vec2 texCoord;
+#else
+varying float vertexDistance;
+varying vec3 normal, lightDir, eyeVec;
+varying vec2 texCoord;
+#endif
+
+void main()
+{
+	vec3 vVertex = (ModelViewMatrix * vertex).xyz;
+	vec4 position = vertex;
+
+	// Pass texture coordinates to fragment shader
+	texCoord = vertexTexCoord;
+
+	// Lighting -- we pass these to the fragment shader
+	normal = (NormalMatrix * vec4(vertexNormal, 0.0)).xyz;
+	lightDir = lightPosition.xyz - vVertex;
+	eyeVec = -vVertex;
+
+	// Implement building stretching to accommodate terrain
+	if (vertex.y <= 0.0) // use vertex here directly to help shader compiler optimization
+	{
+		position.y -= stretch;
+	}
+
+	// Translate every vertex according to the Model View and Projection Matrix
+	vec4 gposition = ModelViewProjectionMatrix * position;
+	gl_Position = gposition;
+
+	// Remember vertex distance
+	vertexDistance = gposition.z;
+}

--- a/resources.qrc
+++ b/resources.qrc
@@ -5,5 +5,7 @@
         <file>data/shaders/wz31.vert</file>
         <file>data/shaders/wz32_tcmask.frag</file>
         <file>data/shaders/wz32_tcmask.vert</file>
+	<file>data/shaders/wz33_tcmask.frag</file>
+        <file>data/shaders/wz33_tcmask.vert</file>
     </qresource>
 </RCC>

--- a/src/basic/WZLight.cpp
+++ b/src/basic/WZLight.cpp
@@ -24,6 +24,15 @@
 
 const static QString base_lightcol_name = "3DView/LightColor";
 
+const static std::array<light_cols_t,LIGHT_WZVER_MAX> lightCol0_default = {{
+	{{{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}},
+	{{{0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f},  {0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f}}}
+}};
+
+static light_cols_t lightCol0_external = lightCol0_default[LIGHT_WZ33];
+light_cols_t lightCol0 = lightCol0_default[LIGHT_WZ33];
+static bool lightCol_use_external = false;
+
 void getExtLightColFromSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
 {
 	QStringList lightCol = QSettings().value(base_lightcol_name + lightcol_suffix).toStringList();
@@ -62,4 +71,17 @@ void saveLightColorSettings()
 	setExtLightColToSettings(LIGHT_SPECULAR, "_S");
 
 	QSettings().setValue(base_lightcol_name + "_UseExternal", lightCol_use_external);
+}
+
+void switchLightToWzVer(LIGHTING_WZVER ver, bool allow_external)
+{
+	if (allow_external && lightCol_use_external)
+		switchLightToExternal();
+	else
+		lightCol0 = lightCol0_default[ver];
+}
+
+void switchLightToExternal()
+{
+	lightCol0 = lightCol0_external;
 }

--- a/src/basic/WZLight.cpp
+++ b/src/basic/WZLight.cpp
@@ -1,0 +1,65 @@
+/*
+	Copyright 2010 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "WZLight.h"
+
+#include <QString>
+#include <QSettings>
+
+const static QString base_lightcol_name = "3DView/LightColor";
+
+void getExtLightColFromSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
+{
+	QStringList lightCol = QSettings().value(base_lightcol_name + lightcol_suffix).toStringList();
+	if (lightCol.count() == 4)
+		for (size_t idx = 0; idx < 4; ++idx) {
+			lightCol0_external[type][idx] = lightCol[static_cast<int>(idx)].toFloat();
+		}
+}
+
+void setExtLightColToSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
+{
+	QStringList lightCol;
+	for (size_t idx = 0; idx < 4; ++idx) {
+		lightCol.append(QString("%1").arg(static_cast<double>(lightCol0_external[type][idx])));
+	}
+	QSettings().setValue(base_lightcol_name + lightcol_suffix, lightCol);
+}
+
+
+void loadLightColorSetting()
+{
+	getExtLightColFromSettings(LIGHT_EMISSIVE, "_E");
+	getExtLightColFromSettings(LIGHT_AMBIENT, "_A");
+	getExtLightColFromSettings(LIGHT_DIFFUSE, "_D");
+	getExtLightColFromSettings(LIGHT_SPECULAR, "_S");
+
+	lightCol_use_external = QSettings().value(base_lightcol_name + "_UseExternal",
+						  lightCol_use_external).toBool();
+}
+
+void saveLightColorSettings()
+{
+	setExtLightColToSettings(LIGHT_EMISSIVE, "_E");
+	setExtLightColToSettings(LIGHT_AMBIENT, "_A");
+	setExtLightColToSettings(LIGHT_DIFFUSE, "_D");
+	setExtLightColToSettings(LIGHT_SPECULAR, "_S");
+
+	QSettings().setValue(base_lightcol_name + "_UseExternal", lightCol_use_external);
+}

--- a/src/basic/WZLight.cpp
+++ b/src/basic/WZLight.cpp
@@ -29,7 +29,7 @@ const static std::array<light_cols_t,LIGHT_WZVER_MAX> lightCol0_default = {{
 	{{{0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f},  {0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f}}}
 }};
 
-static light_cols_t lightCol0_external = lightCol0_default[LIGHT_WZ33];
+light_cols_t lightCol0_external = lightCol0_default[LIGHT_WZ33];
 light_cols_t lightCol0 = lightCol0_default[LIGHT_WZ33];
 static bool lightCol_use_external = false;
 
@@ -84,4 +84,11 @@ void switchLightToWzVer(LIGHTING_WZVER ver, bool allow_external)
 void switchLightToExternal()
 {
 	lightCol0 = lightCol0_external;
+}
+
+bool updateLightToExternalIfNeeded()
+{
+	if (lightCol_use_external)
+		switchLightToExternal();
+	return lightCol_use_external;
 }

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -34,6 +34,9 @@ const static light_cols_t lightCol0_default = {{
 	{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}
 };
 
+//{{0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f},  {0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f}};
+
+
 static light_cols_t lightCol0_external = lightCol0_default;
 static light_cols_t lightCol0 = lightCol0_default;
 static bool lightCol_use_external = false;

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -1,0 +1,44 @@
+/*
+	Copyright 2010 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef WZLIGHT_H
+#define WZLIGHT_H
+
+#include <array>
+
+#include <GL/glew.h>
+
+enum LIGHTING_TYPE {
+	LIGHT_EMISSIVE, LIGHT_AMBIENT, LIGHT_DIFFUSE, LIGHT_SPECULAR, LIGHT_TYPE_MAX
+};
+
+typedef std::array<std::array<GLfloat, 4>, LIGHT_TYPE_MAX> light_cols_t;
+
+const static light_cols_t lightCol0_default = {{
+	{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}
+};
+
+static light_cols_t lightCol0_external = lightCol0_default;
+static light_cols_t lightCol0 = lightCol0_default;
+static bool lightCol_use_external = false;
+
+void loadLightColorSetting();
+void saveLightColorSettings();
+
+#endif // WZLIGHT_H

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -35,12 +35,14 @@ enum LIGHTING_WZVER {
 typedef std::array<GLfloat, 4> light_col_t;
 typedef std::array<light_col_t, LIGHT_TYPE_MAX> light_cols_t;
 
-extern light_cols_t lightCol0_external;
+extern light_cols_t lightCol0_custom;
 extern light_cols_t lightCol0;
 
 void switchLightToWzVer(LIGHTING_WZVER ver, bool allow_external);
-void switchLightToExternal();
-bool updateLightToExternalIfNeeded();
+bool switchLightToCustomIfNeeded();
+
+bool isUsingCustomLightColor();
+void setUseCustomLightColor(bool);
 
 void loadLightColorSetting();
 void saveLightColorSettings();

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -28,18 +28,16 @@ enum LIGHTING_TYPE {
 	LIGHT_EMISSIVE, LIGHT_AMBIENT, LIGHT_DIFFUSE, LIGHT_SPECULAR, LIGHT_TYPE_MAX
 };
 
-typedef std::array<std::array<GLfloat, 4>, LIGHT_TYPE_MAX> light_cols_t;
-
-const static light_cols_t lightCol0_default = {{
-	{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}
+enum LIGHTING_WZVER {
+	LIGHT_WZ32, LIGHT_WZ33, LIGHT_WZVER_MAX
 };
 
-//{{0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f},  {0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f}};
+typedef std::array<std::array<GLfloat, 4>, LIGHT_TYPE_MAX> light_cols_t;
 
+extern light_cols_t lightCol0;
 
-static light_cols_t lightCol0_external = lightCol0_default;
-static light_cols_t lightCol0 = lightCol0_default;
-static bool lightCol_use_external = false;
+void switchLightToWzVer(LIGHTING_WZVER ver, bool allow_external);
+void switchLightToExternal();
 
 void loadLightColorSetting();
 void saveLightColorSettings();

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -35,10 +35,12 @@ enum LIGHTING_WZVER {
 typedef std::array<GLfloat, 4> light_col_t;
 typedef std::array<light_col_t, LIGHT_TYPE_MAX> light_cols_t;
 
+extern light_cols_t lightCol0_external;
 extern light_cols_t lightCol0;
 
 void switchLightToWzVer(LIGHTING_WZVER ver, bool allow_external);
 void switchLightToExternal();
+bool updateLightToExternalIfNeeded();
 
 void loadLightColorSetting();
 void saveLightColorSettings();

--- a/src/basic/WZLight.h
+++ b/src/basic/WZLight.h
@@ -32,7 +32,8 @@ enum LIGHTING_WZVER {
 	LIGHT_WZ32, LIGHT_WZ33, LIGHT_WZVER_MAX
 };
 
-typedef std::array<std::array<GLfloat, 4>, LIGHT_TYPE_MAX> light_cols_t;
+typedef std::array<GLfloat, 4> light_col_t;
+typedef std::array<light_col_t, LIGHT_TYPE_MAX> light_cols_t;
 
 extern light_cols_t lightCol0;
 

--- a/src/formats/Mesh.cpp
+++ b/src/formats/Mesh.cpp
@@ -119,6 +119,7 @@ Mesh::Mesh(const Pie3Level& p3)
 	WZMVertex v[3];
 
 	auto nrmIt = p3.m_normals.begin();
+	bool noPieNormals = p3.normals() == 0;
 
 	defaultConstructor();
 
@@ -133,21 +134,28 @@ Mesh::Mesh(const Pie3Level& p3)
 	// For each pie3 polygon
 	for (itL = p3.m_polygons.begin(); itL != p3.m_polygons.end(); ++itL)
 	{
-		// pie2 integer-type problem?
-		if (itL->getIndex(0) == itL->getIndex(1) || itL->getIndex(1) == itL->getIndex(2) || itL->getIndex(0) == itL->getIndex(2))
+		// Presumably those issues are no longer present in newer models.
+		// N.B. Make sure to advance normals when skipping with normals present
+		if (noPieNormals)
 		{
-			continue;
-		}
-		if (itL->m_texCoords[0] == itL->m_texCoords[1] || itL->m_texCoords[1] == itL->m_texCoords[2] || itL->m_texCoords[0] == itL->m_texCoords[2])
-		{
-			continue;
+			// pie2 integer-type problem?
+			if (itL->getIndex(0) == itL->getIndex(1) || itL->getIndex(1) == itL->getIndex(2) ||
+					itL->getIndex(0) == itL->getIndex(2))
+			{
+				continue;
+			}
+			if (itL->m_texCoords[0] == itL->m_texCoords[1] || itL->m_texCoords[1] == itL->m_texCoords[2] ||
+					itL->m_texCoords[0] == itL->m_texCoords[2])
+			{
+				continue;
+			}
 		}
 
 		v[0] = WZMVertex(p3.m_points[itL->getIndex(0)]);
 		v[1] = WZMVertex(p3.m_points[itL->getIndex(1)]);
 		v[2] = WZMVertex(p3.m_points[itL->getIndex(2)]);
 
-		if (p3.normals() == 0)
+		if (noPieNormals)
 			tmpNrm = WZMVertex(v[1] - v[0]).crossProduct(v[2] - v[0]).normalize();
 
 		// For all 3 vertices of the triangle

--- a/src/formats/Mesh.cpp
+++ b/src/formats/Mesh.cpp
@@ -223,6 +223,8 @@ Mesh::operator Pie3Level() const
 	IndexedTri tri;
 	Pie3Polygon p3Poly;
 	Pie3UV	p3UV;
+	WZMVertex fixedVert;
+	typedef Pie3Vertex::equal_wEps equals;
 
 	p3Poly.m_flags = 0x200;
 
@@ -231,9 +233,9 @@ Mesh::operator Pie3Level() const
 		tri = *itTri;
 		for (i = 0; i < 3; ++i)
 		{
-			typedef Pie3Vertex::equal_wEps equals;
-			WZMVertex fixedVert(m_vertexArray[tri[i]]);
-			mybinder1st<equals> compare(fixedVert);
+			auto curIndex = tri[i];
+			fixedVert = m_vertexArray[curIndex];
+			mybinder1st<equals> compare(fixedVert, equals(0.0001f));
 
 			itPV = std::find_if(p3.m_points.begin(), p3.m_points.end(), compare);
 
@@ -249,11 +251,11 @@ Mesh::operator Pie3Level() const
 			}
 
 			// TODO: deal with UV animation
-			p3UV.u() = m_textureArray[tri[i]].u();
-			p3UV.v() = m_textureArray[tri[i]].v();
+			p3UV.u() = m_textureArray[curIndex].u();
+			p3UV.v() = m_textureArray[curIndex].v();
 			p3Poly.m_texCoords[i] = p3UV;
 
-			p3.m_normals.push_back(m_normalArray[tri[i]]);
+			p3.m_normals.push_back(m_normalArray[curIndex]);
 		}
 		p3.m_polygons.push_back(p3Poly);
 	}

--- a/src/ui/LightColorDock.cpp
+++ b/src/ui/LightColorDock.cpp
@@ -29,6 +29,10 @@ LightColorDock::LightColorDock(light_cols_t &light_cols, QWidget *parent) :
 {
 	m_ui->setupUi(this);
 
+	useCustomColors(false);
+	connect(m_ui->chkCustomColors, SIGNAL(stateChanged(int)),
+		this, SLOT(useCustomColorsChangedOnWidget(int)));
+
 	refreshColorUI();
 	connect(m_ui->colorWidget, SIGNAL(colorsChanged(light_cols_t)),
 		this, SLOT(colorsChangedOnWidget(light_cols_t)));
@@ -60,7 +64,18 @@ void LightColorDock::colorsChangedOnWidget(const light_cols_t &light_cols)
 	emit colorsChanged();
 }
 
+void LightColorDock::useCustomColorsChangedOnWidget(int val)
+{
+	emit useCustomColorsChanged(val == static_cast<int>(Qt::CheckState::Checked));
+}
+
 void LightColorDock::refreshColorUI()
 {
 	m_ui->colorWidget->setLightColors(m_light_cols);
+}
+
+void LightColorDock::useCustomColors(const bool useState)
+{
+	m_ui->chkCustomColors->setCheckState(useState ?
+		Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 }

--- a/src/ui/LightColorDock.cpp
+++ b/src/ui/LightColorDock.cpp
@@ -1,0 +1,66 @@
+/*
+	Copyright 2012 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "LightColorDock.h"
+#include "ui_LightColorDock.h"
+
+#include <QColorDialog>
+
+LightColorDock::LightColorDock(light_cols_t &light_cols, QWidget *parent) :
+	QDockWidget(parent),
+	m_ui(new Ui::LightColorDock),
+	m_light_cols(light_cols)
+{
+	m_ui->setupUi(this);
+
+	refreshColorUI();
+	connect(m_ui->colorWidget, SIGNAL(colorsChanged(light_cols_t)),
+		this, SLOT(colorsChangedOnWidget(light_cols_t)));
+}
+
+LightColorDock::~LightColorDock()
+{
+	delete m_ui;
+}
+
+void LightColorDock::changeEvent(QEvent *event)
+{
+	QDockWidget::changeEvent(event);
+
+	switch (event->type())
+	{
+	case QEvent::LanguageChange:
+		m_ui->retranslateUi(this);
+
+		break;
+	default:
+		break;
+	}
+}
+
+void LightColorDock::colorsChangedOnWidget(const light_cols_t &light_cols)
+{
+	m_light_cols = light_cols;
+	emit colorsChanged();
+}
+
+void LightColorDock::refreshColorUI()
+{
+	m_ui->colorWidget->setLightColors(m_light_cols);
+}

--- a/src/ui/LightColorDock.h
+++ b/src/ui/LightColorDock.h
@@ -1,0 +1,57 @@
+/*
+	Copyright 2012 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LightColorDock_H
+#define LightColorDock_H
+
+#include "WZLight.h"
+
+#include <QDockWidget>
+
+namespace Ui
+{
+	class LightColorDock;
+}
+
+class LightColorDock : public QDockWidget
+{
+	Q_OBJECT
+
+public:
+	LightColorDock(light_cols_t& light_cols, QWidget *parent = nullptr);
+	~LightColorDock();
+
+protected:
+	void changeEvent(QEvent *event);
+
+signals:
+	void colorsChanged();
+
+private slots:
+	void colorsChangedOnWidget(const light_cols_t& light_cols);
+
+public slots:
+	void refreshColorUI();
+
+private:
+	Ui::LightColorDock *m_ui;
+	light_cols_t& m_light_cols;
+};
+
+#endif // LightColorDock_H

--- a/src/ui/LightColorDock.h
+++ b/src/ui/LightColorDock.h
@@ -42,12 +42,15 @@ protected:
 
 signals:
 	void colorsChanged();
+	void useCustomColorsChanged(bool);
 
 private slots:
 	void colorsChangedOnWidget(const light_cols_t& light_cols);
+	void useCustomColorsChangedOnWidget(int);
 
 public slots:
 	void refreshColorUI();
+	void useCustomColors(const bool useState);
 
 private:
 	Ui::LightColorDock *m_ui;

--- a/src/ui/LightColorDock.ui
+++ b/src/ui/LightColorDock.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LightColorDock</class>
+ <widget class="QDockWidget" name="LightColorDock">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>219</width>
+    <height>785</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Light Color</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="LightColorWidget" name="colorWidget" native="true"/>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LightColorWidget</class>
+   <extends>QWidget</extends>
+   <header>LightColorWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/LightColorDock.ui
+++ b/src/ui/LightColorDock.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Light Color</string>
+   <string>Light Properties</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -27,6 +27,22 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
+    <item>
+     <widget class="QGroupBox" name="gbLightControls">
+      <property name="title">
+       <string>Controls</string>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QCheckBox" name="chkCustomColors">
+         <property name="text">
+          <string>Use custom colors</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
     <item>
      <widget class="LightColorWidget" name="colorWidget" native="true"/>
     </item>

--- a/src/ui/LightColorWidget.cpp
+++ b/src/ui/LightColorWidget.cpp
@@ -1,0 +1,185 @@
+/*
+	Copyright 2012 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "LightColorWidget.h"
+#include "ui_LightColorWidget.h"
+
+#include <QColorDialog>
+
+LightColorWidget::LightColorWidget(QWidget *parent) :
+	QWidget(parent),
+	m_ui(new Ui::LightColorWidget)
+{
+	m_ui->setupUi(this);
+
+	m_ui->colorTypeComboBox->addItem("Diffuse", static_cast<int>(LIGHT_DIFFUSE));
+	m_ui->colorTypeComboBox->addItem("Ambient", static_cast<int>(LIGHT_AMBIENT));
+	m_ui->colorTypeComboBox->addItem("Specular", static_cast<int>(LIGHT_SPECULAR));
+	m_ui->colorTypeComboBox->addItem("Emissive", static_cast<int>(LIGHT_EMISSIVE));
+
+	connect(m_ui->colorRedSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeRedComponent(double)));
+	connect(m_ui->colorRedSlider, SIGNAL(valueChanged(int)), this, SLOT(changeRedComponent(int)));
+	connect(m_ui->colorGreenSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeGreenComponent(double)));
+	connect(m_ui->colorGreenSlider, SIGNAL(valueChanged(int)), this, SLOT(changeGreenComponent(int)));
+	connect(m_ui->colorBlueSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeBlueComponent(double)));
+	connect(m_ui->colorBlueSlider, SIGNAL(valueChanged(int)), this, SLOT(changeBlueComponent(int)));
+
+	// disable wip parts
+	m_ui->colorAllCheckBox->setDisabled(true);
+}
+
+LightColorWidget::~LightColorWidget()
+{
+	delete m_ui;
+}
+
+void LightColorWidget::changeEvent(QEvent *event)
+{
+	QWidget::changeEvent(event);
+
+	switch (event->type())
+	{
+	case QEvent::LanguageChange:
+		m_ui->retranslateUi(this);
+
+		break;
+	default:
+		break;
+	}
+}
+
+void LightColorWidget::setLightColors(const light_cols_t &light_cols)
+{
+	m_colors = light_cols;
+	on_colorTypeComboBox_currentIndexChanged(m_ui->colorTypeComboBox->currentIndex());
+}
+
+void LightColorWidget::setColorOnUI(const QColor& color)
+{
+	QPixmap pix(5, 5);
+	pix.fill(color);
+
+	m_ui->colorPreview->setPixmap(pix);
+
+	m_ui->colorRedSpinBox->blockSignals(true);
+	m_ui->colorRedSpinBox->setValue(color.redF());
+	m_ui->colorRedSpinBox->blockSignals(false);
+	m_ui->colorRedSlider->blockSignals(true);
+	m_ui->colorRedSlider->setValue(color.red());
+	m_ui->colorRedSlider->blockSignals(false);
+
+	m_ui->colorGreenSpinBox->blockSignals(true);
+	m_ui->colorGreenSpinBox->setValue(color.greenF());
+	m_ui->colorGreenSpinBox->blockSignals(false);
+	m_ui->colorGreenSlider->blockSignals(true);
+	m_ui->colorGreenSlider->setValue(color.green());
+	m_ui->colorGreenSlider->blockSignals(false);
+
+	m_ui->colorBlueSpinBox->blockSignals(true);
+	m_ui->colorBlueSpinBox->setValue(color.blueF());
+	m_ui->colorBlueSpinBox->blockSignals(false);
+	m_ui->colorBlueSlider->blockSignals(true);
+	m_ui->colorBlueSlider->setValue(color.blue());
+	m_ui->colorBlueSlider->blockSignals(false);
+}
+
+void LightColorWidget::applyColor(const QColor &color)
+{
+	if (color.isValid())
+	{
+		setColorOnUI(color);
+
+		LIGHTING_TYPE type = static_cast<LIGHTING_TYPE>(
+			m_ui->colorTypeComboBox->itemData(m_ui->colorTypeComboBox->currentIndex()).toInt());
+		m_colors[type][0] = color.redF();
+		m_colors[type][1] = color.greenF();
+		m_colors[type][2] = color.blueF();
+
+		emit colorsChanged(m_colors);
+	}
+}
+
+void LightColorWidget::on_colorTypeComboBox_currentIndexChanged(int index)
+{
+	LIGHTING_TYPE type = static_cast<LIGHTING_TYPE>(m_ui->colorTypeComboBox->itemData(index).toInt());
+	setColorOnUI(QColor::fromRgbF(m_colors[type][0], m_colors[type][1], m_colors[type][2]));
+}
+
+void LightColorWidget::on_colorDialogButton_clicked()
+{
+	applyColor(QColorDialog::getColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(),
+				   m_ui->colorGreenSpinBox->value(), m_ui->colorBlueSpinBox->value()), this));
+}
+
+void LightColorWidget::changeRedComponent(int value)
+{
+	double dval = value / 255.0;
+	if (m_ui->colorRedSpinBox->value() != dval)
+	{
+		m_ui->colorRedSpinBox->setValue(dval);
+	}
+}
+
+void LightColorWidget::changeRedComponent(double value)
+{
+	if (m_ui->colorRedSlider->value() != value * 255)
+	{
+		m_ui->colorRedSlider->setValue(value * 255);
+	}
+
+	applyColor(QColor::fromRgbF(value, m_ui->colorGreenSpinBox->value(), m_ui->colorBlueSpinBox->value()));
+}
+
+void LightColorWidget::changeGreenComponent(int value)
+{
+	double dval = value / 255.0;
+	if (m_ui->colorGreenSpinBox->value() != dval)
+	{
+		m_ui->colorGreenSpinBox->setValue(dval);
+	}
+}
+
+void LightColorWidget::changeGreenComponent(double value)
+{
+	if (m_ui->colorGreenSlider->value() != value * 255)
+	{
+		m_ui->colorGreenSlider->setValue(value * 255);
+	}
+
+	applyColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(), value, m_ui->colorBlueSpinBox->value()));
+}
+
+void LightColorWidget::changeBlueComponent(int value)
+{
+	double dval = value / 255.0;
+	if (m_ui->colorBlueSpinBox->value() != dval)
+	{
+		m_ui->colorBlueSpinBox->setValue(dval);
+	}
+}
+
+void LightColorWidget::changeBlueComponent(double value)
+{
+	if (m_ui->colorBlueSlider->value() != value * 255)
+	{
+		m_ui->colorBlueSlider->setValue(value * 255);
+	}
+
+	applyColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(), m_ui->colorGreenSpinBox->value(), value));
+}

--- a/src/ui/LightColorWidget.h
+++ b/src/ui/LightColorWidget.h
@@ -1,0 +1,68 @@
+/*
+	Copyright 2012 Warzone 2100 Project
+
+	This file is part of WMIT.
+
+	WMIT is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	WMIT is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with WMIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LightColorWidget_H
+#define LightColorWidget_H
+
+#include <QWidget>
+
+#include "WZLight.h"
+
+namespace Ui
+{
+	class LightColorWidget;
+}
+
+class LightColorWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	LightColorWidget(QWidget *parent = nullptr);
+	~LightColorWidget();
+
+protected:
+	void changeEvent(QEvent *event);
+
+signals:
+	void colorsChanged(const light_cols_t& light_cols);
+
+public slots:
+	void setLightColors(const light_cols_t& light_cols);
+
+private slots:
+	void on_colorTypeComboBox_currentIndexChanged(int index);
+	void on_colorDialogButton_clicked();
+
+	void changeRedComponent(int value);
+	void changeRedComponent(double value);
+	void changeGreenComponent(int value);
+	void changeGreenComponent(double value);
+	void changeBlueComponent(int value);
+	void changeBlueComponent(double value);
+
+private:
+	Ui::LightColorWidget *m_ui;
+	light_cols_t m_colors;
+
+	void setColorOnUI(const QColor &color);
+	void applyColor(const QColor &color);
+};
+
+#endif // LightColorWidget_H

--- a/src/ui/LightColorWidget.ui
+++ b/src/ui/LightColorWidget.ui
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LightColorWidget</class>
+ <widget class="QWidget" name="LightColorWidgetContents">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>219</width>
+    <height>318</height>
+   </rect>
+  </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QGroupBox" name="colorGroupBox">
+      <property name="title">
+       <string>Color</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QComboBox" name="colorTypeComboBox"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="colorAllCheckBox">
+         <property name="text">
+          <string>Lock all channels</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="colorLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="colorGreenLabel">
+           <property name="text">
+            <string>G:</string>
+           </property>
+           <property name="buddy">
+            <cstring>colorGreenSlider</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="colorBlueLabel">
+           <property name="text">
+            <string>B:</string>
+           </property>
+           <property name="buddy">
+            <cstring>colorBlueSlider</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="colorRedLabel">
+           <property name="text">
+            <string>R:</string>
+           </property>
+           <property name="buddy">
+            <cstring>colorRedSlider</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSlider" name="colorRedSlider">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximum">
+            <number>255</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSlider" name="colorGreenSlider">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximum">
+            <number>255</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSlider" name="colorBlueSlider">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximum">
+            <number>255</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QDoubleSpinBox" name="colorRedSpinBox">
+           <property name="accelerated">
+            <bool>true</bool>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QDoubleSpinBox" name="colorGreenSpinBox">
+           <property name="accelerated">
+            <bool>true</bool>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QDoubleSpinBox" name="colorBlueSpinBox">
+           <property name="accelerated">
+            <bool>true</bool>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="colorPreview">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::Box</enum>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="colorDialogButton">
+         <property name="palette">
+          <palette>
+           <active>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>127</red>
+               <green>127</green>
+               <blue>127</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </active>
+           <inactive>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>127</red>
+               <green>127</green>
+               <blue>127</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </inactive>
+           <disabled>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>127</red>
+               <green>127</green>
+               <blue>127</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </disabled>
+          </palette>
+         </property>
+         <property name="text">
+          <string>Color dialog</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+   </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -812,7 +812,7 @@ void MainWindow::shaderAction(int type)
 				"\nNOTE: Model might temporarily go into stealth mode due to this error...\n\n" +
 				errMessage);
 		}
-	};
+	}
 
 	// Handle light
 	switch (static_cast<wz_shader_type_t>(type))

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -134,6 +134,7 @@ MainWindow::MainWindow(QWZM &model, QWidget *parent) : QMainWindow(parent),
 	connect(m_ui->actionShowLightSource, SIGNAL(toggled(bool)), m_ui->centralWidget, SLOT(setDrawLightSource(bool)));
 	connect(m_ui->actionLink_Light_Source_To_Camera, SIGNAL(toggled(bool)), m_ui->centralWidget, SLOT(setLinkLightToCamera(bool)));
 	connect(m_ui->actionAnimate, SIGNAL(toggled(bool)), m_ui->centralWidget, SLOT(setAnimateState(bool)));
+	connect(m_ui->actionEnable_Ecm_Effect, SIGNAL(toggled(bool)), this, SLOT(setEcmState(bool)));
 	connect(m_ui->actionAboutQt, SIGNAL(triggered()), QApplication::instance(), SLOT(aboutQt()));
 	connect(m_ui->actionSetTeamColor, SIGNAL(triggered()), this, SLOT(actionSetTeamColor()));
 
@@ -326,6 +327,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 	settings.setValue("3DView/LinkLightToCamera", m_ui->actionLink_Light_Source_To_Camera->isChecked());
 	settings.setValue("3DView/EnableUserShaders", m_actionEnableUserShaders->isChecked());
 	settings.setValue("3DView/Animate", m_ui->actionAnimate->isChecked());
+	settings.setValue("3DView/EcmEffect", m_ui->actionEnable_Ecm_Effect->isChecked());
 	settings.setValue("3DView/ShowConnectors", m_ui->actionShow_Connectors->isChecked());
 	settings.setValue("3DView/ShaderTag", wz_shader_type_tag[getShaderType()]);
 
@@ -761,6 +763,8 @@ void MainWindow::viewerInitialized()
 	m_actionEnableUserShaders->setChecked(m_settings->value("3DView/EnableUserShaders", false).toBool());
 	m_ui->actionAnimate->setChecked(m_settings->value("3DView/Animate", true).toBool());
 
+	m_ui->actionEnable_Ecm_Effect->setChecked(m_settings->value("3DView/EcmEffect", false).toBool());
+
 	actionEnableUserShaders(m_actionEnableUserShaders->isChecked());
 
 	m_actionEnableTangentInShaders->setChecked(m_model->getEnableTangentsInShaders());
@@ -843,6 +847,11 @@ void MainWindow::shaderAction(int type)
 	updateModelRender();
 
 	setWindowTitle(buildAppTitle());
+}
+
+void MainWindow::setEcmState(bool checked)
+{
+	m_model->setEcmState(checked);
 }
 
 void MainWindow::scaleXYZChanged(double val)

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -41,6 +41,7 @@
 #include <QVariant>
 
 #include "Pie.h"
+#include "WZLight.h"
 
 QString MainWindow::buildAppTitle()
 {
@@ -635,6 +636,10 @@ bool MainWindow::reloadShader(wz_shader_type_t type, bool user_shader, QString *
 			pathvert = WMIT_SHADER_WZ32TC_DEFPATH_VERT;
 			pathfrag = WMIT_SHADER_WZ32TC_DEFPATH_FRAG;
 			break;
+		case WZ_SHADER_WZ33:
+			pathvert = WMIT_SHADER_WZ33TC_DEFPATH_VERT;
+			pathfrag = WMIT_SHADER_WZ33TC_DEFPATH_FRAG;
+			break;
 		default:
 			break;
 		}
@@ -809,11 +814,22 @@ void MainWindow::shaderAction(int type)
 		}
 	};
 
+	// Handle light
+	switch (static_cast<wz_shader_type_t>(type))
+	{
+	case WZ_SHADER_WZ33:
+		switchLightToWzVer(LIGHT_WZ33, true);
+		break;
+	default:
+		switchLightToWzVer(LIGHT_WZ32, true);
+	}
+
 	if (!useUserShader)
 		reloadShader(stype, false);
 
 	if (static_cast<wz_shader_type_t>(type) != WZ_SHADER_NONE)
 	{
+
 		if (!m_model->setActiveShader(static_cast<wz_shader_type_t>(type)))
 		{
 		    QMessageBox::warning(this, "Shaders error",
@@ -1094,6 +1110,7 @@ void MainWindow::updateRecentFilesMenu()
 
 void MainWindow::updateModelRender()
 {
+	m_ui->centralWidget->setLightColors();
 	m_ui->centralWidget->update();
 }
 

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -125,6 +125,7 @@ private slots:
 	void updateConnectorsView();
 	void viewerInitialized();
 	void shaderAction(int);
+	void setEcmState(bool checked);
 
 	// transformations
 	void scaleXYZChanged(double scale);

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -34,6 +34,7 @@
 #include "QWZM.h"
 #include "Pie.h"
 #include "wmit.h"
+#include "WZLight.h"
 
 class MaterialDock;
 class TransformDock;
@@ -42,6 +43,7 @@ class ImportDialog;
 class ExportDialog;
 class TextureDialog;
 class UVEditor;
+class LightColorDock;
 
 namespace Ui
 {
@@ -140,12 +142,15 @@ private slots:
 
 	void materialChangedFromUI(const WZMaterial& mat);
 
+	void lightColorChangedFromUI();
+
 private:
 	Ui::MainWindow *m_ui;
 
 	MaterialDock *m_materialDock;
 	TransformDock *m_transformDock;
 	MeshDock *m_meshDock;
+	LightColorDock *m_lightColorDock;
 
 	TextureDialog *m_textureDialog;
 	UVEditor *m_UVEditor;

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -143,6 +143,7 @@ private slots:
 	void materialChangedFromUI(const WZMaterial& mat);
 
 	void lightColorChangedFromUI();
+	void useCustomLightColorChangedFromUI(bool);
 
 private:
 	Ui::MainWindow *m_ui;

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -85,6 +85,7 @@
     </property>
     <addaction name="actionRenderer"/>
     <addaction name="actionAnimate"/>
+    <addaction name="actionEnable_Ecm_Effect"/>
     <addaction name="actionSetTeamColor"/>
     <addaction name="separator"/>
     <addaction name="actionShowModelCenter"/>
@@ -369,6 +370,14 @@
   <action name="actionImport_Connectors">
    <property name="text">
     <string>Import Connectors...</string>
+   </property>
+  </action>
+  <action name="actionEnable_Ecm_Effect">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Ecm Effect</string>
    </property>
   </action>
  </widget>

--- a/src/ui/MaterialDock.cpp
+++ b/src/ui/MaterialDock.cpp
@@ -28,6 +28,8 @@ MaterialDock::MaterialDock(QWidget *parent) :
 {
 	m_ui->setupUi(this);
 
+	connect(m_ui->colorWidget, SIGNAL(colorsChanged(light_cols_t)), this, SLOT(colorsChanged(light_cols_t)));
+
 	connect(m_ui->shininessDoubleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeShininess(double)));
 	connect(m_ui->shininessSlider, SIGNAL(valueChanged(int)), this, SLOT(changeShininess(int)));
 }
@@ -52,9 +54,24 @@ void MaterialDock::changeEvent(QEvent *event)
 	}
 }
 
+void copyMaterialColors(const WZMVertex &mat_col, light_col_t& cols)
+{
+	for (size_t idx = 0; idx < 4; ++idx) {
+		cols[idx] = mat_col[idx];
+	}
+}
+
 void MaterialDock::setMaterial(const WZMaterial &mat)
 {
 	m_material = mat;
+
+	light_cols_t cols;
+	copyMaterialColors(mat.vals[WZM_MAT_AMBIENT], cols[LIGHT_AMBIENT]);
+	copyMaterialColors(mat.vals[WZM_MAT_EMISSIVE], cols[LIGHT_EMISSIVE]);
+	copyMaterialColors(mat.vals[WZM_MAT_DIFFUSE], cols[LIGHT_DIFFUSE]);
+	copyMaterialColors(mat.vals[WZM_MAT_SPECULAR], cols[LIGHT_SPECULAR]);
+
+	m_ui->colorWidget->setLightColors(cols);
 
 	setShininessOnUI(m_material.shininess);
 }
@@ -87,5 +104,22 @@ void MaterialDock::changeShininess(double value)
 	}
 
 	m_material.shininess = value;
+	emit materialChanged(m_material);
+}
+
+void setMaterialColors(WZMVertex &mat_col, const light_col_t& cols)
+{
+	for (size_t idx = 0; idx < 4; ++idx) {
+		mat_col[idx] = cols[idx];
+	}
+}
+
+void MaterialDock::colorsChanged(const light_cols_t &light_cols)
+{
+	setMaterialColors(m_material.vals[WZM_MAT_AMBIENT], light_cols[LIGHT_AMBIENT]);
+	setMaterialColors(m_material.vals[WZM_MAT_EMISSIVE], light_cols[LIGHT_EMISSIVE]);
+	setMaterialColors(m_material.vals[WZM_MAT_DIFFUSE], light_cols[LIGHT_DIFFUSE]);
+	setMaterialColors(m_material.vals[WZM_MAT_SPECULAR], light_cols[LIGHT_SPECULAR]);
+
 	emit materialChanged(m_material);
 }

--- a/src/ui/MaterialDock.cpp
+++ b/src/ui/MaterialDock.cpp
@@ -28,23 +28,8 @@ MaterialDock::MaterialDock(QWidget *parent) :
 {
 	m_ui->setupUi(this);
 
-	m_ui->colorTypeComboBox->addItem("Diffuse", static_cast<int>(WZM_MAT_DIFFUSE));
-	m_ui->colorTypeComboBox->addItem("Ambient", static_cast<int>(WZM_MAT_AMBIENT));
-	m_ui->colorTypeComboBox->addItem("Specular", static_cast<int>(WZM_MAT_SPECULAR));
-	m_ui->colorTypeComboBox->addItem("Emissive", static_cast<int>(WZM_MAT_EMISSIVE));
-
-	connect(m_ui->colorRedSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeRedComponent(double)));
-	connect(m_ui->colorRedSlider, SIGNAL(valueChanged(int)), this, SLOT(changeRedComponent(int)));
-	connect(m_ui->colorGreenSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeGreenComponent(double)));
-	connect(m_ui->colorGreenSlider, SIGNAL(valueChanged(int)), this, SLOT(changeGreenComponent(int)));
-	connect(m_ui->colorBlueSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeBlueComponent(double)));
-	connect(m_ui->colorBlueSlider, SIGNAL(valueChanged(int)), this, SLOT(changeBlueComponent(int)));
-
 	connect(m_ui->shininessDoubleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(changeShininess(double)));
 	connect(m_ui->shininessSlider, SIGNAL(valueChanged(int)), this, SLOT(changeShininess(int)));
-
-	// disable wip parts
-	m_ui->colorAllCheckBox->setDisabled(true);
 }
 
 MaterialDock::~MaterialDock()
@@ -71,39 +56,7 @@ void MaterialDock::setMaterial(const WZMaterial &mat)
 {
 	m_material = mat;
 
-	wzm_material_t type = static_cast<wzm_material_t>(m_ui->colorTypeComboBox->itemData(m_ui->colorTypeComboBox->currentIndex()).toInt());
-
-    setColorOnUI(QColor::fromRgbF(m_material.vals[type].x(), m_material.vals[type].y(), m_material.vals[type].z()));
 	setShininessOnUI(m_material.shininess);
-}
-
-void MaterialDock::setColorOnUI(const QColor& color)
-{
-	QPixmap pix(5, 5);
-	pix.fill(color);
-
-	m_ui->colorPreview->setPixmap(pix);
-
-	m_ui->colorRedSpinBox->blockSignals(true);
-	m_ui->colorRedSpinBox->setValue(color.redF());
-	m_ui->colorRedSpinBox->blockSignals(false);
-	m_ui->colorRedSlider->blockSignals(true);
-	m_ui->colorRedSlider->setValue(color.red());
-	m_ui->colorRedSlider->blockSignals(false);
-
-	m_ui->colorGreenSpinBox->blockSignals(true);
-	m_ui->colorGreenSpinBox->setValue(color.greenF());
-	m_ui->colorGreenSpinBox->blockSignals(false);
-	m_ui->colorGreenSlider->blockSignals(true);
-	m_ui->colorGreenSlider->setValue(color.green());
-	m_ui->colorGreenSlider->blockSignals(false);
-
-	m_ui->colorBlueSpinBox->blockSignals(true);
-	m_ui->colorBlueSpinBox->setValue(color.blueF());
-	m_ui->colorBlueSpinBox->blockSignals(false);
-	m_ui->colorBlueSlider->blockSignals(true);
-	m_ui->colorBlueSlider->setValue(color.blue());
-	m_ui->colorBlueSlider->blockSignals(false);
 }
 
 void MaterialDock::setShininessOnUI(const float shininess)
@@ -115,90 +68,6 @@ void MaterialDock::setShininessOnUI(const float shininess)
 	m_ui->shininessSlider->blockSignals(true);
 	m_ui->shininessSlider->setValue(shininess * 10);
 	m_ui->shininessSlider->blockSignals(false);
-}
-
-void MaterialDock::applyColor(const QColor &color)
-{
-	if (color.isValid())
-	{
-		setColorOnUI(color);
-
-		wzm_material_t type = static_cast<wzm_material_t>(m_ui->colorTypeComboBox->itemData(m_ui->colorTypeComboBox->currentIndex()).toInt());
-        m_material.vals[type].x() = color.redF();
-        m_material.vals[type].y() = color.greenF();
-        m_material.vals[type].z() = color.blueF();
-
-		emit materialChanged(m_material);
-	}
-}
-
-void MaterialDock::on_colorTypeComboBox_currentIndexChanged(int index)
-{
-	wzm_material_t type = static_cast<wzm_material_t>(m_ui->colorTypeComboBox->itemData(index).toInt());
-    setColorOnUI(QColor::fromRgbF(m_material.vals[type].x(), m_material.vals[type].y(), m_material.vals[type].z()));
-}
-
-void MaterialDock::on_colorDialogButton_clicked()
-{
-	applyColor(QColorDialog::getColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(),
-				   m_ui->colorGreenSpinBox->value(), m_ui->colorBlueSpinBox->value()), this));
-}
-
-void MaterialDock::changeRedComponent(int value)
-{
-	double dval = value / 255.0;
-	if (m_ui->colorRedSpinBox->value() != dval)
-	{
-		m_ui->colorRedSpinBox->setValue(dval);
-	}
-}
-
-void MaterialDock::changeRedComponent(double value)
-{
-	if (m_ui->colorRedSlider->value() != value * 255)
-	{
-		m_ui->colorRedSlider->setValue(value * 255);
-	}
-
-	applyColor(QColor::fromRgbF(value, m_ui->colorGreenSpinBox->value(), m_ui->colorBlueSpinBox->value()));
-}
-
-void MaterialDock::changeGreenComponent(int value)
-{
-	double dval = value / 255.0;
-	if (m_ui->colorGreenSpinBox->value() != dval)
-	{
-		m_ui->colorGreenSpinBox->setValue(dval);
-	}
-}
-
-void MaterialDock::changeGreenComponent(double value)
-{
-	if (m_ui->colorGreenSlider->value() != value * 255)
-	{
-		m_ui->colorGreenSlider->setValue(value * 255);
-	}
-
-	applyColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(), value, m_ui->colorBlueSpinBox->value()));
-}
-
-void MaterialDock::changeBlueComponent(int value)
-{
-	double dval = value / 255.0;
-	if (m_ui->colorBlueSpinBox->value() != dval)
-	{
-		m_ui->colorBlueSpinBox->setValue(dval);
-	}
-}
-
-void MaterialDock::changeBlueComponent(double value)
-{
-	if (m_ui->colorBlueSlider->value() != value * 255)
-	{
-		m_ui->colorBlueSlider->setValue(value * 255);
-	}
-
-	applyColor(QColor::fromRgbF(m_ui->colorRedSpinBox->value(), m_ui->colorGreenSpinBox->value(), value));
 }
 
 void MaterialDock::changeShininess(int value)

--- a/src/ui/MaterialDock.h
+++ b/src/ui/MaterialDock.h
@@ -47,16 +47,6 @@ public slots:
 	void setMaterial(const WZMaterial& mat);
 
 private slots:
-	void on_colorTypeComboBox_currentIndexChanged(int index);
-	void on_colorDialogButton_clicked();
-
-	void changeRedComponent(int value);
-	void changeRedComponent(double value);
-	void changeGreenComponent(int value);
-	void changeGreenComponent(double value);
-	void changeBlueComponent(int value);
-	void changeBlueComponent(double value);
-
 	void changeShininess(int value);
 	void changeShininess(double value);
 
@@ -64,9 +54,7 @@ private:
 	Ui::MaterialDock *m_ui;
 	WZMaterial m_material;
 
-	void setColorOnUI(const QColor &color);
 	void setShininessOnUI(const float shininess);
-	void applyColor(const QColor &color);
 };
 
 #endif // MATERIALDOCK_H

--- a/src/ui/MaterialDock.h
+++ b/src/ui/MaterialDock.h
@@ -21,6 +21,7 @@
 #define MATERIALDOCK_H
 
 #include "WZM.h"
+#include "WZLight.h"
 
 #include <QDockWidget>
 
@@ -49,6 +50,7 @@ public slots:
 private slots:
 	void changeShininess(int value);
 	void changeShininess(double value);
+	void colorsChanged(const light_cols_t& light_cols);
 
 private:
 	Ui::MaterialDock *m_ui;

--- a/src/ui/MaterialDock.ui
+++ b/src/ui/MaterialDock.ui
@@ -15,219 +15,21 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
-     <widget class="QGroupBox" name="colorGroupBox">
-      <property name="title">
-       <string>Color</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_5">
-       <item>
-        <widget class="QComboBox" name="colorTypeComboBox"/>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="colorAllCheckBox">
-         <property name="text">
-          <string>Lock all channels</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="colorLayout">
-         <item row="1" column="0">
-          <widget class="QLabel" name="colorGreenLabel">
-           <property name="text">
-            <string>G:</string>
-           </property>
-           <property name="buddy">
-            <cstring>colorGreenSlider</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="colorBlueLabel">
-           <property name="text">
-            <string>B:</string>
-           </property>
-           <property name="buddy">
-            <cstring>colorBlueSlider</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="colorRedLabel">
-           <property name="text">
-            <string>R:</string>
-           </property>
-           <property name="buddy">
-            <cstring>colorRedSlider</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSlider" name="colorRedSlider">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TicksBelow</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSlider" name="colorGreenSlider">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TicksBelow</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSlider" name="colorBlueSlider">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TicksBelow</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QDoubleSpinBox" name="colorRedSpinBox">
-           <property name="accelerated">
-            <bool>true</bool>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.010000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QDoubleSpinBox" name="colorGreenSpinBox">
-           <property name="accelerated">
-            <bool>true</bool>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.010000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QDoubleSpinBox" name="colorBlueSpinBox">
-           <property name="accelerated">
-            <bool>true</bool>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.010000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QLabel" name="colorPreview">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>50</height>
-          </size>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::Box</enum>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="colorDialogButton">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Button">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>127</red>
-               <green>127</green>
-               <blue>127</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Button">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>127</red>
-               <green>127</green>
-               <blue>127</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Button">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>127</red>
-               <green>127</green>
-               <blue>127</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
-         <property name="text">
-          <string>Color dialog</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <widget class="LightColorWidget" name="colorWidget" native="true">
+      <layout class="QVBoxLayout" name="verticalLayout_5"/>
      </widget>
     </item>
     <item>
@@ -297,6 +99,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LightColorWidget</class>
+   <extends>QWidget</extends>
+   <header>LightColorWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/MaterialDock.ui
+++ b/src/ui/MaterialDock.ui
@@ -28,9 +28,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="LightColorWidget" name="colorWidget" native="true">
-      <layout class="QVBoxLayout" name="verticalLayout_5"/>
-     </widget>
+     <widget class="LightColorWidget" name="colorWidget" native="true"/>
     </item>
     <item>
      <widget class="QGroupBox" name="shininessGroupBox">

--- a/src/ui/TextureDialog.cpp
+++ b/src/ui/TextureDialog.cpp
@@ -135,9 +135,6 @@ void TextureDialog::createTextureIcons(const QString& workdir, const QString& mo
 	m_work_dir = workdir;
 	m_model_filepath = modelname;
 
-	if (workdir.isEmpty() || modelname.isEmpty() || !m_texnames.size())
-		return;
-
 	QMap<wzm_texture_type_t, QString>::const_iterator it;
 	for (it = m_texnames.begin(); it != m_texnames.end(); ++it)
 	{
@@ -155,6 +152,13 @@ void TextureDialog::setSearchDirs(const QStringList &list)
 void TextureDialog::setTexturesMap(const QMap<wzm_texture_type_t, QString> &texnames)
 {
 	m_texnames = texnames;
+	// Add missing ones
+	for (int i = WZM_TEX__FIRST; i < WZM_TEX__LAST; ++i)
+	{
+		wzm_texture_type_t ttyp = static_cast<wzm_texture_type_t>(i);
+		if (!m_texnames.contains(ttyp))
+			m_texnames.insert(ttyp, QString());
+	}
 }
 
 void TextureDialog::getTexturesFilepath(QMap<wzm_texture_type_t, QString> &files) const
@@ -179,12 +183,11 @@ void TextureDialog::getTexturesFilepath(QMap<wzm_texture_type_t, QString> &files
 
 QString TextureDialog::findTexture(wzm_texture_type_t type) const
 {
-	QFileInfo modelnfo(m_model_filepath);
 	QString fileTexName = m_texnames.value(type);
 
+	// Pre-configured search
 	if (!fileTexName.isEmpty())
 	{
-		// Pre-configured search
 		foreach(QString filePath, m_predefined_textures)
 		{
 			if (fileTexName.compare(QFileInfo(filePath).fileName(), Qt::CaseSensitive) == 0)
@@ -192,8 +195,15 @@ QString TextureDialog::findTexture(wzm_texture_type_t type) const
 				return filePath;
 			}
 		}
+	}
 
-		// Local search
+	if (m_model_filepath.isEmpty())
+		return QString();
+
+	// Local search
+	QFileInfo modelnfo(m_model_filepath);
+	if (!fileTexName.isEmpty())
+	{
 		QFileInfo nfo(modelnfo.path() + "/" + fileTexName);
 		if (nfo.exists())
 		{

--- a/src/widgets/QWZM.cpp
+++ b/src/widgets/QWZM.cpp
@@ -40,6 +40,7 @@ QWZM::QWZM(QObject *parent):
 	m_animation_elapsed_msecs(-1.),
 	m_shadertime(0.f),
 	m_drawConnectors(false),
+	m_ecmState(0),
 	m_enableTangentsInShaders(true)
 {
 	defaultConstructor();
@@ -644,9 +645,6 @@ bool QWZM::initShader(int type)
 	uniLoc = shader->uniformLocation("fogEnabled");
 	shader->setUniformValue(uniLoc, GLint(0));
 
-	uniLoc = shader->uniformLocation("ecmEffect");
-	shader->setUniformValue(uniLoc, GLint(0));
-
 	switch (type)
 	{
 	case WZ_SHADER_WZ32:
@@ -722,6 +720,9 @@ bool QWZM::bindShader(int type)
 
 	uniloc = shader->uniformLocation("graphicsCycle");
 	shader->setUniformValue(uniloc, GLfloat(m_shadertime));
+
+	uniloc = shader->uniformLocation("ecmEffect");
+	shader->setUniformValue(uniloc, GLint(m_ecmState));
 
 	switch (type)
 	{
@@ -896,6 +897,11 @@ void QWZM::addMesh(const Mesh& mesh)
 {
 	WZM::addMesh(mesh);
 	meshCountChanged(meshes(), getMeshNames());
+}
+
+void QWZM::setEcmState(bool enable)
+{
+	m_ecmState = enable ? 1 : 0;
 }
 
 void QWZM::slotRemoveActiveMesh()

--- a/src/widgets/QWZM.cpp
+++ b/src/widgets/QWZM.cpp
@@ -655,22 +655,6 @@ bool QWZM::initShader(int type)
 		uniLoc = shader->uniformLocation("colour");
 		shader->setUniformValue(uniLoc,	1.f, 1.f, 1.f, 1.f);
 
-		uniLoc = shader->uniformLocation("sceneColor");
-		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_EMISSIVE][0], lightCol0[LIGHT_EMISSIVE][1],
-				lightCol0[LIGHT_EMISSIVE][2], lightCol0[LIGHT_EMISSIVE][3]);
-
-		uniLoc = shader->uniformLocation("ambient");
-		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_AMBIENT][0], lightCol0[LIGHT_AMBIENT][1],
-				lightCol0[LIGHT_AMBIENT][2], lightCol0[LIGHT_AMBIENT][3]);
-
-		uniLoc = shader->uniformLocation("diffuse");
-		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_DIFFUSE][0], lightCol0[LIGHT_DIFFUSE][1],
-				lightCol0[LIGHT_DIFFUSE][2], lightCol0[LIGHT_DIFFUSE][3]);
-
-		uniLoc = shader->uniformLocation("specular");
-		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_SPECULAR][0], lightCol0[LIGHT_SPECULAR][1],
-				lightCol0[LIGHT_SPECULAR][2], lightCol0[LIGHT_SPECULAR][3]);
-
 		break;
 	}
 
@@ -743,6 +727,23 @@ bool QWZM::bindShader(int type)
 
 		uniloc = shader->uniformLocation("lightPosition");
 		shader->setUniformValue(uniloc,	render_posSun * render_mtxModelView_preAnim.inverted());
+
+		uniloc = shader->uniformLocation("sceneColor");
+		shader->setUniformValue(uniloc,	lightCol0[LIGHT_EMISSIVE][0], lightCol0[LIGHT_EMISSIVE][1],
+				lightCol0[LIGHT_EMISSIVE][2], lightCol0[LIGHT_EMISSIVE][3]);
+
+		uniloc = shader->uniformLocation("ambient");
+		shader->setUniformValue(uniloc,	lightCol0[LIGHT_AMBIENT][0], lightCol0[LIGHT_AMBIENT][1],
+				lightCol0[LIGHT_AMBIENT][2], lightCol0[LIGHT_AMBIENT][3]);
+
+		uniloc = shader->uniformLocation("diffuse");
+		shader->setUniformValue(uniloc,	lightCol0[LIGHT_DIFFUSE][0], lightCol0[LIGHT_DIFFUSE][1],
+				lightCol0[LIGHT_DIFFUSE][2], lightCol0[LIGHT_DIFFUSE][3]);
+
+		uniloc = shader->uniformLocation("specular");
+		shader->setUniformValue(uniloc,	lightCol0[LIGHT_SPECULAR][0], lightCol0[LIGHT_SPECULAR][1],
+				lightCol0[LIGHT_SPECULAR][2], lightCol0[LIGHT_SPECULAR][3]);
+
 /*
 		uniloc = shader->uniformLocation("sceneColor");
 		shader->setUniformValue(uniloc,

--- a/src/widgets/QWZM.cpp
+++ b/src/widgets/QWZM.cpp
@@ -21,6 +21,7 @@
 #include "Pie.h"
 
 #include "QtGLView.h"
+#include "WZLight.h"
 
 static const char vertexAtributeName[] = "vertex";
 static const char vertexNormalAtributeName[] = "vertexNormal";
@@ -587,15 +588,6 @@ void QWZM::clearTextureUnits(int type)
 	}
 }
 
-enum WZ_LIGHTING_TYPE
-{
-	LIGHT_EMISSIVE,
-	LIGHT_AMBIENT,
-	LIGHT_DIFFUSE,
-	LIGHT_SPECULAR,
-	LIGHT_MAX
-};
-
 bool QWZM::initShader(int type)
 {
 	if (!m_shaderman)
@@ -648,26 +640,24 @@ bool QWZM::initShader(int type)
 		uniLoc = shader->uniformLocation("alphaTest");
 		shader->setUniformValue(uniLoc, GLint(0));
 
-		const GLfloat defaultLight[4][4] = {{0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f},  {0.f, 0.f, 0.f, 1.f},  {1.f, 1.f, 1.f, 1.f}};
-
 		uniLoc = shader->uniformLocation("colour");
 		shader->setUniformValue(uniLoc,	1.f, 1.f, 1.f, 1.f);
 
 		uniLoc = shader->uniformLocation("sceneColor");
-		shader->setUniformValue(uniLoc,	defaultLight[LIGHT_EMISSIVE][0], defaultLight[LIGHT_EMISSIVE][1],
-				defaultLight[LIGHT_EMISSIVE][2], defaultLight[LIGHT_EMISSIVE][3]);
+		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_EMISSIVE][0], lightCol0[LIGHT_EMISSIVE][1],
+				lightCol0[LIGHT_EMISSIVE][2], lightCol0[LIGHT_EMISSIVE][3]);
 
 		uniLoc = shader->uniformLocation("ambient");
-		shader->setUniformValue(uniLoc,	defaultLight[LIGHT_AMBIENT][0], defaultLight[LIGHT_AMBIENT][1],
-				defaultLight[LIGHT_AMBIENT][2], defaultLight[LIGHT_AMBIENT][3]);
+		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_AMBIENT][0], lightCol0[LIGHT_AMBIENT][1],
+				lightCol0[LIGHT_AMBIENT][2], lightCol0[LIGHT_AMBIENT][3]);
 
 		uniLoc = shader->uniformLocation("diffuse");
-		shader->setUniformValue(uniLoc,	defaultLight[LIGHT_DIFFUSE][0], defaultLight[LIGHT_DIFFUSE][1],
-				defaultLight[LIGHT_DIFFUSE][2], defaultLight[LIGHT_DIFFUSE][3]);
+		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_DIFFUSE][0], lightCol0[LIGHT_DIFFUSE][1],
+				lightCol0[LIGHT_DIFFUSE][2], lightCol0[LIGHT_DIFFUSE][3]);
 
 		uniLoc = shader->uniformLocation("specular");
-		shader->setUniformValue(uniLoc,	defaultLight[LIGHT_SPECULAR][0], defaultLight[LIGHT_SPECULAR][1],
-				defaultLight[LIGHT_SPECULAR][2], defaultLight[LIGHT_SPECULAR][3]);
+		shader->setUniformValue(uniLoc,	lightCol0[LIGHT_SPECULAR][0], lightCol0[LIGHT_SPECULAR][1],
+				lightCol0[LIGHT_SPECULAR][2], lightCol0[LIGHT_SPECULAR][3]);
 
 		break;
 	}

--- a/src/widgets/QWZM.cpp
+++ b/src/widgets/QWZM.cpp
@@ -514,7 +514,10 @@ QString QWZM::shaderTypeToString(wz_shader_type_t type)
 		str = "WZ 3.1 shaders";
 		break;
 	case WZ_SHADER_WZ32:
-		str = "WZ 3.2+ shaders";
+		str = "WZ 3.2 shaders";
+		break;
+	case WZ_SHADER_WZ33:
+		str = "WZ 3.3 shaders";
 		break;
 	default:
 		str = "<Unknown>";
@@ -547,6 +550,7 @@ bool QWZM::setupTextureUnits(int type)
 	{
 	case WZ_SHADER_WZ31:
 	case WZ_SHADER_WZ32:
+	case WZ_SHADER_WZ33:
 		if (hasGLRenderTexture(WZM_TEX_DIFFUSE))
 			activateAndBindTexture(0, m_gl_textures[WZM_TEX_DIFFUSE]);
 		else
@@ -578,6 +582,7 @@ void QWZM::clearTextureUnits(int type)
 	{
 	case WZ_SHADER_WZ31:
 	case WZ_SHADER_WZ32:
+	case WZ_SHADER_WZ33:
 		deactivateTexture(3);
 		deactivateTexture(2);
 		deactivateTexture(1);
@@ -612,6 +617,7 @@ bool QWZM::initShader(int type)
 			smTexLoc = shader->uniformLocation("Texture3");
 			break;
 		case WZ_SHADER_WZ32:
+		case WZ_SHADER_WZ33:
 			baseTexLoc = shader->uniformLocation("Texture");
 			tcTexLoc = shader->uniformLocation("TextureTcmask");
 			nmTexLoc = shader->uniformLocation("TextureNormal");
@@ -637,6 +643,7 @@ bool QWZM::initShader(int type)
 	switch (type)
 	{
 	case WZ_SHADER_WZ32:
+	case WZ_SHADER_WZ33:
 		uniLoc = shader->uniformLocation("alphaTest");
 		shader->setUniformValue(uniLoc, GLint(0));
 
@@ -709,6 +716,7 @@ bool QWZM::bindShader(int type)
 	switch (type)
 	{
 	case WZ_SHADER_WZ32:
+	case WZ_SHADER_WZ33:
 		uniloc = shader->uniformLocation("ModelViewMatrix");
 		shader->setUniformValue(uniloc,	render_mtxModelView);
 

--- a/src/widgets/QWZM.cpp
+++ b/src/widgets/QWZM.cpp
@@ -38,6 +38,7 @@ QWZM::QWZM(QObject *parent):
 	m_drawTangentAndBitangent(false),
 	m_drawCenterPoint(false),
 	m_animation_elapsed_msecs(-1.),
+	m_shadertime(0.f),
 	m_drawConnectors(false),
 	m_enableTangentsInShaders(true)
 {
@@ -374,6 +375,12 @@ void QWZM::animate()
 	using namespace std::chrono;
 	duration<double> time_span = steady_clock::now() - m_timeAnimationStarted;
 	m_animation_elapsed_msecs = time_span.count() * 1000.;
+
+	// Do it like they do it in WZ
+	uint32_t base = static_cast<uint32_t>(m_animation_elapsed_msecs) % 1000;
+	if (base > 500)
+		base = 1000 - base;	// cycle
+	m_shadertime = base / 1000.0f;
 }
 
 void QWZM::clear()
@@ -712,6 +719,9 @@ bool QWZM::bindShader(int type)
 		shader->setUniformValue(uniloc, GLint(1));
 	else
 		shader->setUniformValue(uniloc, GLint(0));
+
+	uniloc = shader->uniformLocation("graphicsCycle");
+	shader->setUniformValue(uniloc, GLfloat(m_shadertime));
 
 	switch (type)
 	{

--- a/src/widgets/QWZM.h
+++ b/src/widgets/QWZM.h
@@ -155,6 +155,7 @@ private:
 	bool m_drawCenterPoint;
 
 	double m_animation_elapsed_msecs;
+	float m_shadertime;
 	bool m_drawConnectors;
 
 	int m_enableTangentsInShaders;

--- a/src/widgets/QWZM.h
+++ b/src/widgets/QWZM.h
@@ -126,6 +126,8 @@ public:
 
 	void addMesh (const Mesh& mesh);
 
+	void setEcmState(bool enable);
+
 private:
 	Q_DISABLE_COPY(QWZM)
 	void defaultConstructor();
@@ -157,6 +159,7 @@ private:
 	double m_animation_elapsed_msecs;
 	float m_shadertime;
 	bool m_drawConnectors;
+	int m_ecmState;
 
 	int m_enableTangentsInShaders;
 };

--- a/src/widgets/QWZM.h
+++ b/src/widgets/QWZM.h
@@ -40,7 +40,9 @@ enum wz_shader_type_t {WZ_SHADER_NONE,
 		       WZ_SHADER_WZ31,
 		       WZ_SHADER_WZ32,
 		       WZ_SHADER_WZ33,
-		       WZ_SHADER__LAST, WZ_SHADER__FIRST = WZ_SHADER_NONE};
+		       WZ_SHADER__LAST,
+		       WZ_SHADER__LATEST = WZ_SHADER_WZ33,
+		       WZ_SHADER__FIRST = WZ_SHADER_NONE};
 
 static const int wz_shader_type_tag[WZ_SHADER__LAST] = {
 	0,

--- a/src/widgets/QWZM.h
+++ b/src/widgets/QWZM.h
@@ -39,12 +39,14 @@
 enum wz_shader_type_t {WZ_SHADER_NONE,
 		       WZ_SHADER_WZ31,
 		       WZ_SHADER_WZ32,
+		       WZ_SHADER_WZ33,
 		       WZ_SHADER__LAST, WZ_SHADER__FIRST = WZ_SHADER_NONE};
 
 static const int wz_shader_type_tag[WZ_SHADER__LAST] = {
 	0,
 	31,
-	32
+	32,
+	33
 };
 
 class Pie3Model;

--- a/src/widgets/QWZM.h
+++ b/src/widgets/QWZM.h
@@ -22,7 +22,7 @@
 
 #include <GL/glew.h>
 
-#include <time.h>
+#include <chrono>
 
 #include <QtCore>
 #include <QString>
@@ -145,14 +145,14 @@ private:
 
 	int m_active_mesh;
 	bool m_pending_changes;
-	clock_t m_timeAnimationStarted;
+	std::chrono::steady_clock::time_point m_timeAnimationStarted;
 
 	QColor m_tcmaskColour;
 
 	bool m_drawNormals, m_drawTangentAndBitangent;
 	bool m_drawCenterPoint;
 
-	float m_animation_elapsed_msecs;
+	double m_animation_elapsed_msecs;
 	bool m_drawConnectors;
 
 	int m_enableTangentsInShaders;

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -37,41 +37,12 @@
 #include "IGLTexturedRenderable.h"
 #include "IGLShaderRenderable.h"
 #include "IAnimatable.h"
+#include "WZLight.h"
 
 using namespace qglviewer;
 
-enum LIGHTING_TYPE {
-	LIGHT_EMISSIVE, LIGHT_AMBIENT, LIGHT_DIFFUSE, LIGHT_SPECULAR, LIGHT_TYPE_MAX
-};
-
-typedef std::array<std::array<GLfloat, 4>, LIGHT_TYPE_MAX> light_cols_t;
 const Vec lightPos(2.25, 6., 4.5);
-const static light_cols_t lightCol0_default = {{
-	{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}
-};
-static light_cols_t lightCol0_external = lightCol0_default;
-static light_cols_t lightCol0 = lightCol0_default;
-static bool lightCol_use_external = false;
 
-const static QString base_lightcol_name = "3DView/LightColor";
-
-void getExtLightColFromSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
-{
-	QStringList lightCol = QSettings().value(base_lightcol_name + lightcol_suffix).toStringList();
-	if (lightCol.count() == 4)
-		for (size_t idx = 0; idx < 4; ++idx) {
-			lightCol0_external[type][idx] = lightCol[static_cast<int>(idx)].toFloat();
-		}
-}
-
-void setExtLightColToSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
-{
-	QStringList lightCol;
-	for (size_t idx = 0; idx < 4; ++idx) {
-		lightCol.append(QString("%1").arg(static_cast<double>(lightCol0_external[type][idx])));
-	}
-	QSettings().setValue(base_lightcol_name + lightcol_suffix, lightCol);
-}
 
 QtGLView::QtGLView(QWidget *parent) :
 		QGLViewer(parent),
@@ -85,13 +56,8 @@ QtGLView::QtGLView(QWidget *parent) :
 	setGridIsDrawn(true);
 	setAxisIsDrawn(true);
 
-	getExtLightColFromSettings(LIGHT_EMISSIVE, "_E");
-	getExtLightColFromSettings(LIGHT_AMBIENT, "_A");
-	getExtLightColFromSettings(LIGHT_DIFFUSE, "_D");
-	getExtLightColFromSettings(LIGHT_SPECULAR, "_S");
+	loadLightColorSetting();
 
-	lightCol_use_external = QSettings().value(base_lightcol_name + "_UseExternal",
-						  lightCol_use_external).toBool();
 	if (lightCol_use_external)
 	{
 		lightCol0 = lightCol0_external;
@@ -112,12 +78,7 @@ QtGLView::~QtGLView()
 	}
 */
 
-	setExtLightColToSettings(LIGHT_EMISSIVE, "_E");
-	setExtLightColToSettings(LIGHT_AMBIENT, "_A");
-	setExtLightColToSettings(LIGHT_DIFFUSE, "_D");
-	setExtLightColToSettings(LIGHT_SPECULAR, "_S");
-
-	QSettings().setValue(base_lightcol_name + "_UseExternal", lightCol_use_external);
+	saveLightColorSettings();
 }
 
 void QtGLView::animate()

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -148,6 +148,7 @@ void QtGLView::draw()
 	larr[2] = lvec.z;
 
 	glLightfv(GL_LIGHT0, GL_POSITION, larr);
+	setLightColors();
 
 	foreach(IGLRenderable* obj, renderList)
 	{

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -51,6 +51,7 @@ const static light_cols_t lightCol0_default = {{
 };
 static light_cols_t lightCol0_external = lightCol0_default;
 static light_cols_t lightCol0 = lightCol0_default;
+static bool lightCol_use_external = false;
 
 const static QString base_lightcol_name = "3DView/LightColor";
 
@@ -89,7 +90,9 @@ QtGLView::QtGLView(QWidget *parent) :
 	getExtLightColFromSettings(LIGHT_DIFFUSE, "_D");
 	getExtLightColFromSettings(LIGHT_SPECULAR, "_S");
 
-	if (QSettings().value(base_lightcol_name + "_UseExternal").toBool())
+	lightCol_use_external = QSettings().value(base_lightcol_name + "_UseExternal",
+						  lightCol_use_external).toBool();
+	if (lightCol_use_external)
 	{
 		lightCol0 = lightCol0_external;
 	}
@@ -113,6 +116,8 @@ QtGLView::~QtGLView()
 	setExtLightColToSettings(LIGHT_AMBIENT, "_A");
 	setExtLightColToSettings(LIGHT_DIFFUSE, "_D");
 	setExtLightColToSettings(LIGHT_SPECULAR, "_S");
+
+	QSettings().setValue(base_lightcol_name + "_UseExternal", lightCol_use_external);
 }
 
 void QtGLView::animate()

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -43,7 +43,6 @@ using namespace qglviewer;
 
 const Vec lightPos(2.25, 6., 4.5);
 
-
 QtGLView::QtGLView(QWidget *parent) :
 		QGLViewer(parent),
 		drawLightSource(true),
@@ -57,11 +56,6 @@ QtGLView::QtGLView(QWidget *parent) :
 	setAxisIsDrawn(true);
 
 	loadLightColorSetting();
-
-	if (lightCol_use_external)
-	{
-		lightCol0 = lightCol0_external;
-	}
 }
 
 QtGLView::~QtGLView()
@@ -89,16 +83,21 @@ void QtGLView::animate()
 	}
 }
 
+void QtGLView::setLightColors()
+{
+	glLightModelfv(GL_LIGHT_MODEL_AMBIENT, lightCol0[LIGHT_EMISSIVE].data());
+	glLightfv(GL_LIGHT0, GL_AMBIENT, lightCol0[LIGHT_AMBIENT].data());
+	glLightfv(GL_LIGHT0, GL_DIFFUSE, lightCol0[LIGHT_DIFFUSE].data());
+	glLightfv(GL_LIGHT0, GL_SPECULAR, lightCol0[LIGHT_SPECULAR].data());
+}
+
 void QtGLView::init()
 {
 	// initialize GLEW
 	glewInit();
 
-	glLightModelfv(GL_LIGHT_MODEL_AMBIENT, lightCol0[LIGHT_EMISSIVE].data());
+	setLightColors();
 	glLightModelf(GL_LIGHT_MODEL_LOCAL_VIEWER, 1.0);
-	glLightfv(GL_LIGHT0, GL_AMBIENT, lightCol0[LIGHT_AMBIENT].data());
-	glLightfv(GL_LIGHT0, GL_DIFFUSE, lightCol0[LIGHT_DIFFUSE].data());
-	glLightfv(GL_LIGHT0, GL_SPECULAR, lightCol0[LIGHT_SPECULAR].data());
 	glEnable(GL_LIGHT0);
 
 	glEnable(GL_LIGHTING);

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -54,8 +54,6 @@ QtGLView::QtGLView(QWidget *parent) :
 	setShortcut(DISPLAY_FPS, 0); // Disable stuff that won't work.
 	setGridIsDrawn(true);
 	setAxisIsDrawn(true);
-
-	loadLightColorSetting();
 }
 
 QtGLView::~QtGLView()
@@ -71,8 +69,6 @@ QtGLView::~QtGLView()
  		texture.pTexture->destroy();
 	}
 */
-
-	saveLightColorSettings();
 }
 
 void QtGLView::animate()

--- a/src/widgets/QtGLView.cpp
+++ b/src/widgets/QtGLView.cpp
@@ -49,6 +49,25 @@ static GLfloat lightCol0[LIGHT_TYPE_MAX][4] = {
 	{0.0f, 0.0f, 0.0f, 1.0f},  {0.5f, 0.5f, 0.5f, 1.0f}, {0.8f, 0.8f, 0.8f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}
 };
 
+const static QString base_lightcol_name = "3DView/LightColor";
+
+void getLightColFromSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
+{
+	QStringList lightCol = QSettings().value(base_lightcol_name + lightcol_suffix).toStringList();
+	if (lightCol.count() == 4)
+		for (int idx = 0; idx < 4; ++idx) {
+			lightCol0[type][idx] = lightCol[idx].toFloat();
+		}
+}
+
+void setLightColToSettings(const LIGHTING_TYPE type, const char* lightcol_suffix)
+{
+	QStringList lightCol;
+	for (int idx = 0; idx < 4; ++idx) {
+		lightCol.append(QString("%1").arg(static_cast<double>(lightCol0[type][idx])));
+	}
+	QSettings().setValue(base_lightcol_name + lightcol_suffix, lightCol);
+}
 
 QtGLView::QtGLView(QWidget *parent) :
 		QGLViewer(parent),
@@ -61,6 +80,11 @@ QtGLView::QtGLView(QWidget *parent) :
 	setShortcut(DISPLAY_FPS, 0); // Disable stuff that won't work.
 	setGridIsDrawn(true);
 	setAxisIsDrawn(true);
+
+	getLightColFromSettings(LIGHT_EMISSIVE, "_E");
+	getLightColFromSettings(LIGHT_AMBIENT, "_A");
+	getLightColFromSettings(LIGHT_DIFFUSE, "_D");
+	getLightColFromSettings(LIGHT_SPECULAR, "_S");
 }
 
 QtGLView::~QtGLView()
@@ -76,6 +100,11 @@ QtGLView::~QtGLView()
  		texture.pTexture->destroy();
 	}
 */
+
+	setLightColToSettings(LIGHT_EMISSIVE, "_E");
+	setLightColToSettings(LIGHT_AMBIENT, "_A");
+	setLightColToSettings(LIGHT_DIFFUSE, "_D");
+	setLightColToSettings(LIGHT_SPECULAR, "_S");
 }
 
 void QtGLView::animate()

--- a/src/widgets/QtGLView.h
+++ b/src/widgets/QtGLView.h
@@ -75,6 +75,7 @@ public:
                             QString *errString);
 	virtual void unloadShader(int type);
 
+	void setLightColors();
 public slots:
 	void setDrawLightSource(bool draw);
 	void setLinkLightToCamera(bool link);

--- a/src/wmit.h
+++ b/src/wmit.h
@@ -2,7 +2,7 @@
 
 #define WMIT_ORG "WMIT"
 #define WMIT_APPNAME "WMIT"
-#define WMIT_VER_STR "0.6.10"
+#define WMIT_VER_STR "0.6.11 Beta"
 
 #define WMIT_SETTINGS_IMPORTVAL "importFolder"
 #define WMIT_SETTINGS_EXPORTVAL "exportFolder"

--- a/src/wmit.h
+++ b/src/wmit.h
@@ -2,7 +2,7 @@
 
 #define WMIT_ORG "WMIT"
 #define WMIT_APPNAME "WMIT"
-#define WMIT_VER_STR "0.6.11 Beta"
+#define WMIT_VER_STR "0.6.11"
 
 #define WMIT_SETTINGS_IMPORTVAL "importFolder"
 #define WMIT_SETTINGS_EXPORTVAL "exportFolder"

--- a/src/wmit.h
+++ b/src/wmit.h
@@ -18,6 +18,9 @@
 #define WMIT_SHADER_WZ32TC_DEFPATH_VERT ":/data/shaders/wz32_tcmask.vert"
 #define WMIT_SHADER_WZ32TC_DEFPATH_FRAG ":/data/shaders/wz32_tcmask.frag"
 
+#define WMIT_SHADER_WZ33TC_DEFPATH_VERT ":/data/shaders/wz33_tcmask.vert"
+#define WMIT_SHADER_WZ33TC_DEFPATH_FRAG ":/data/shaders/wz33_tcmask.frag"
+
 #define WMIT_IMAGES_NOTEXTURE ":/data/images/notex.png"
 
 enum wmit_filetype_t { WMIT_FT_PIE = 0, WMIT_FT_PIE2, WMIT_FT_WZM, WMIT_FT_OBJ };

--- a/wmit.pro
+++ b/wmit.pro
@@ -38,6 +38,7 @@ HEADERS += \
     src/basic/Polygon_t.hpp \
     src/basic/Vector.h \
     src/basic/VectorTypes.h \
+    src/basic/WZLight.h \
     src/widgets/QWZM.h \
     src/ui/MaterialDock.h \
     src/ui/meshdock.h
@@ -56,6 +57,7 @@ SOURCES += \
     src/main.cpp \
     src/Generic.cpp \
     src/basic/GLTexture.cpp \
+    src/basic/WZLight.cpp \
     src/widgets/QWZM.cpp \
     src/widgets/QtGLView.cpp \
     src/ui/TextureDialog.cpp \

--- a/wmit.pro
+++ b/wmit.pro
@@ -41,6 +41,7 @@ HEADERS += \
     src/basic/WZLight.h \
     src/widgets/QWZM.h \
     src/ui/MaterialDock.h \
+    src/ui/LightColorWidget.h \
     src/ui/meshdock.h
     
 SOURCES += \
@@ -63,6 +64,7 @@ SOURCES += \
     src/ui/TextureDialog.cpp \
     src/ui/TexConfigDialog.cpp \
     src/ui/MaterialDock.cpp \
+    src/ui/LightColorWidget.cpp \
     src/ui/meshdock.cpp
     
 FORMS += \
@@ -74,6 +76,7 @@ FORMS += \
     src/ui/TextureDialog.ui \
     src/ui/TexConfigDialog.ui \
     src/ui/MaterialDock.ui \
+    src/ui/LightColorWidget.ui \
     src/ui/meshdock.ui
     
 OTHER_FILES += \

--- a/wmit.pro
+++ b/wmit.pro
@@ -42,6 +42,7 @@ HEADERS += \
     src/widgets/QWZM.h \
     src/ui/MaterialDock.h \
     src/ui/LightColorWidget.h \
+    src/ui/LightColorDock.h \
     src/ui/meshdock.h
     
 SOURCES += \
@@ -65,6 +66,7 @@ SOURCES += \
     src/ui/TexConfigDialog.cpp \
     src/ui/MaterialDock.cpp \
     src/ui/LightColorWidget.cpp \
+    src/ui/LightColorDock.cpp \
     src/ui/meshdock.cpp
     
 FORMS += \
@@ -77,6 +79,7 @@ FORMS += \
     src/ui/TexConfigDialog.ui \
     src/ui/MaterialDock.ui \
     src/ui/LightColorWidget.ui \
+    src/ui/LightColorDock.ui \
     src/ui/meshdock.ui
     
 OTHER_FILES += \


### PR DESCRIPTION
Includes changes for a "general release with some improvements":
- Update light settings for each shader to reflect values as they were in WZ at the time
- Add vanilla 3.3 shaders and corresponding UI controls
- Change animation logic to be run at same speed regardless of your hardware
- Allow enabling ECM effect
- Allow customizing light colors and persist custom color in settings
- Pre-create placeholders for all texture types in texture dialog (empty placeholders do not affect model)
- Address issue where PIE normals were mixed-up after loading a model where polygons had same text coordinates or indices


