### PR TITLE
Improve animation import

### DIFF
--- a/src/formats/Pie.cpp
+++ b/src/formats/Pie.cpp
@@ -459,6 +459,10 @@ bool ApieAnimObject::readStandaloneAniStream(std::istream &fin)
 		return false;
 	}
 
+	// Cut off CR
+	if (!str.empty() && str.back() == '\r')
+		str = str.substr(0, str.size() - 1);
+
 	// Attempt to read mesh name
 	if (str.find(PIE_MODEL_DIRECTIVE_ANIMOBJECT) == 0)
 	{

--- a/src/formats/Pie.cpp
+++ b/src/formats/Pie.cpp
@@ -443,12 +443,43 @@ bool ApieAnimObject::readStandaloneAniFile(const char *file)
 	if (!fin.is_open())
 		return false;
 
-	return tryToReadDirective(fin, PIE_MODEL_DIRECTIVE_ANIMOBJECT, false,
+	return readStandaloneAniStream(fin);
+}
+
+bool ApieAnimObject::readStandaloneAniStream(std::istream &fin)
+{
+	std::string str;
+	std::streampos entrypoint = fin.tellg();
+
+	clear();
+
+	std::getline(fin, str);
+	if (fin.fail())
+	{
+		return false;
+	}
+
+	// Attempt to read mesh name
+	if (str.find(PIE_MODEL_DIRECTIVE_ANIMOBJECT) == 0)
+	{
+		str.clear();
+
+		fin.clear();
+		fin.seekg(entrypoint);
+	}
+
+	if (tryToReadDirective(fin, PIE_MODEL_DIRECTIVE_ANIMOBJECT, false,
 		[this](std::istream& inn)
 		{
 			return read(inn);
-		}
-	);
+		}))
+	{
+			name = str;
+			// read up to next line
+			std::getline(fin, str);
+			return true;
+	}
+	return false;
 }
 
 const char *getPieDirectiveName(PIE_OPT_DIRECTIVES dir)
@@ -481,4 +512,23 @@ const char *getPieDirectiveDescription(PIE_OPT_DIRECTIVES dir)
 	default:
 		return "";
 	}
+}
+
+bool ApieAnimList::readAniFile(const char *file)
+{
+	std::ifstream fin;
+
+	clear();
+
+	fin.open(file, std::ios::in | std::ios::binary);
+
+	if (!fin.is_open())
+		return false;
+
+	ApieAnimObject nextAnim;
+	while (nextAnim.readStandaloneAniStream(fin))
+	{
+		anims.emplace_back(nextAnim);
+	};
+	return count() > 0;
 }

--- a/src/formats/Pie.h
+++ b/src/formats/Pie.h
@@ -156,16 +156,29 @@ public:
 class ApieAnimObject
 {
 public:
+	std::string name;
 	int time, cycles, numframes;
 	std::vector<ApieAnimFrame> frames;
 
 	bool isValid() const {return !frames.empty();}
-	void clear() {frames.clear();}
+	void clear() {frames.clear(); name.clear();}
 
 	bool read(std::istream& in);
 	void write(std::ostream& out) const;
 
+	bool readStandaloneAniStream(std::istream& fin);
 	bool readStandaloneAniFile(const char* file);
+};
+
+class ApieAnimList
+{
+public:
+	std::vector<ApieAnimObject> anims;
+
+	void clear() {anims.clear();}
+	size_t count() const {return anims.size();}
+
+	bool readAniFile(const char* file);
 };
 
 template<typename V, typename P, typename C>

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -1049,6 +1049,11 @@ void MainWindow::actionImport_Animation()
 		// Might disable some anim-unfriendly actions
 		doAfterModelWasLoaded(true);
 	}
+	else
+	{
+		QMessageBox::warning(this, "Import error",
+			"Unable to import animation file!");
+	}
 }
 
 void MainWindow::actionImport_Connectors()

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -1066,7 +1066,7 @@ void MainWindow::actionImport_Animation()
 						meshIdx = items.indexOf(item);
 				}
 
-				if ((meshIdx < 0) or !okFlag)
+				if ((meshIdx < 0) || !okFlag)
 					break;
 
 				auto &mesh = m_model->getMesh(meshIdx);

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -1028,7 +1028,7 @@ void MainWindow::actionImport_Animation()
 	if (anim_path.isEmpty())
 	    return;
 
-	const char* title_str = "Animation Import";
+	const QString title_str = tr("Animation Import");
 
 	ApieAnimList pieAnim;
 	if (pieAnim.readAniFile(anim_path.toLocal8Bit()))
@@ -1049,21 +1049,25 @@ void MainWindow::actionImport_Animation()
 		}
 		else
 		{
+			bool okFlag;
 			for (int cnt = 0; cnt < int(pieAnim.anims.size()); cnt++)
 			{
 				auto &anim = pieAnim.anims[cnt];
 				int meshIdx = -1;
 				{
 					QStringList items = m_model->getMeshNames();
+					QString lbl = tr("Select mesh for animation import:");
+					if (!anim.name.empty())
+						lbl = tr("Select mesh for animation import: %1").arg(anim.name.c_str());
 
-					QString item = QInputDialog::getItem(this, tr("Select mesh for animation import"),
-									     QString(anim.name.c_str()), items, 0, false);
+					QString item = QInputDialog::getItem(this, title_str,
+						lbl, items, 0, false, &okFlag);
 					if (!item.isEmpty())
 						meshIdx = items.indexOf(item);
 				}
 
-				if (meshIdx < 0)
-					return;
+				if ((meshIdx < 0) or !okFlag)
+					break;
 
 				auto &mesh = m_model->getMesh(meshIdx);
 				mesh.importPieAnimation(anim);


### PR DESCRIPTION
This allow one to import multiple animations from a single file (likely produced by a Blender script). Animations will be silently mapped to each mesh when number of animations equals number of meshes. Otherwise user will be asked to confirm target mesh before importing each animation.