### PR TITLE
Rejuvenate GH actions

### DIFF
--- a/.github/workflows/CI_macOS.yml
+++ b/.github/workflows/CI_macOS.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         brew install gnu-getopt
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.7.2
+      uses: jurplel/install-qt-action@v2.13.0
       with:
         version: 5.12.9
     - name: Verify Qt install + version

--- a/.github/workflows/CI_macOS.yml
+++ b/.github/workflows/CI_macOS.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         OUTPUT_DIR="${HOME}/output"
         echo "OUTPUT_DIR=${OUTPUT_DIR}"
-        echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
         mkdir -p "${OUTPUT_DIR}"
     - name: Configure
       run: |
@@ -69,7 +69,7 @@ jobs:
         WMIT_OUTPUT_ZIP="${OUTPUT_DIR}/wmit_macOS.zip"
         mv "./build/WMIT.zip" "${WMIT_OUTPUT_ZIP}"
         echo "WMIT_OUTPUT_ZIP=${WMIT_OUTPUT_ZIP}"
-        echo "::set-env name=WMIT_OUTPUT_ZIP::${WMIT_OUTPUT_ZIP}"
+        echo "WMIT_OUTPUT_ZIP=${WMIT_OUTPUT_ZIP}" >> $GITHUB_ENV
     - name: Output Debug Info
       shell: sh {0}
       run: |

--- a/.github/workflows/CI_macOS.yml
+++ b/.github/workflows/CI_macOS.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.13.0
       with:
-        version: 5.12.9
+        version: 5.15.2
     - name: Verify Qt install + version
       run: |
         echo "Qt version:"

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -115,7 +115,7 @@ jobs:
         echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
         echo "::set-output name=WZ_DEPLOY_RELEASE::${WZ_DEPLOY_RELEASE}"
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.7.2
+      uses: jurplel/install-qt-action@v2.13.0
       with:
         version: 5.12.9
         arch: ${{ steps.settings.outputs.QTCI_ARCH }}

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -103,16 +103,17 @@ jobs:
         # Export Variables
 
         # Export everything important to environment variables (for future steps)
-        echo "VCPKG_DEFAULT_TRIPLET=${VCPKG_DEFAULT_TRIPLET}" >> $GITHUB_ENV
-        echo "WZ_VC_TARGET_PLATFORMNAME=${WZ_VC_TARGET_PLATFORMNAME}" >> $GITHUB_ENV
-        echo "WZ_BUILD_DESC=${WZ_BUILD_DESC}" >> $GITHUB_ENV
-        echo "TCI_ARCH=${QTCI_ARCH}" >> $GITHUB_ENV
+        echo "VCPKG_DEFAULT_TRIPLET=${VCPKG_DEFAULT_TRIPLET}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_VC_TARGET_PLATFORMNAME=${WZ_VC_TARGET_PLATFORMNAME}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_BUILD_DESC=${WZ_BUILD_DESC}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "TCI_ARCH=${QTCI_ARCH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "::set-output name=QTCI_ARCH::${QTCI_ARCH}"
-        echo "WZ_VC_GENERATOR=${WZ_VC_GENERATOR}" >> $GITHUB_ENV
-        #echo "WZ_VC_TOOLCHAIN=${WZ_VC_TOOLCHAIN}" >> $GITHUB_ENV
-        echo "WZ_VISUAL_STUDIO_INSTALL_PATH=${WZ_VISUAL_STUDIO_INSTALL_PATH}" >> $GITHUB_ENV
-        echo "VCPKG_VISUAL_STUDIO_PATH=${VCPKG_VISUAL_STUDIO_PATH}" >> $GITHUB_ENV
-        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
+        echo "WZ_VC_GENERATOR=${WZ_VC_GENERATOR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        #echo "WZ_VC_TOOLCHAIN=${WZ_VC_TOOLCHAIN}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "::set-output name=WZ_VISUAL_STUDIO_INSTALL_PATH::${WZ_VISUAL_STUDIO_INSTALL_PATH}"
+        echo "WZ_VISUAL_STUDIO_INSTALL_PATH=${WZ_VISUAL_STUDIO_INSTALL_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "VCPKG_VISUAL_STUDIO_PATH=${VCPKG_VISUAL_STUDIO_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "::set-output name=WZ_DEPLOY_RELEASE::${WZ_DEPLOY_RELEASE}"
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.13.0

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -106,7 +106,7 @@ jobs:
         echo "VCPKG_DEFAULT_TRIPLET=${VCPKG_DEFAULT_TRIPLET}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "WZ_VC_TARGET_PLATFORMNAME=${WZ_VC_TARGET_PLATFORMNAME}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "WZ_BUILD_DESC=${WZ_BUILD_DESC}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "TCI_ARCH=${QTCI_ARCH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "QTCI_ARCH=${QTCI_ARCH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "::set-output name=QTCI_ARCH::${QTCI_ARCH}"
         echo "WZ_VC_GENERATOR=${WZ_VC_GENERATOR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         #echo "WZ_VC_TOOLCHAIN=${WZ_VC_TOOLCHAIN}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.13.0
       with:
-        version: 5.12.9
+        version: 5.15.2
         arch: ${{ steps.settings.outputs.QTCI_ARCH }}
         dir: 'C:/Qt'
     - name: Verify Qt install + version

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -103,16 +103,16 @@ jobs:
         # Export Variables
 
         # Export everything important to environment variables (for future steps)
-        echo "::set-env name=VCPKG_DEFAULT_TRIPLET::${VCPKG_DEFAULT_TRIPLET}"
-        echo "::set-env name=WZ_VC_TARGET_PLATFORMNAME::${WZ_VC_TARGET_PLATFORMNAME}"
-        echo "::set-env name=WZ_BUILD_DESC::${WZ_BUILD_DESC}"
-        echo "::set-env name=QTCI_ARCH::${QTCI_ARCH}"
+        echo "VCPKG_DEFAULT_TRIPLET=${VCPKG_DEFAULT_TRIPLET}" >> $GITHUB_ENV
+        echo "WZ_VC_TARGET_PLATFORMNAME=${WZ_VC_TARGET_PLATFORMNAME}" >> $GITHUB_ENV
+        echo "WZ_BUILD_DESC=${WZ_BUILD_DESC}" >> $GITHUB_ENV
+        echo "TCI_ARCH=${QTCI_ARCH}" >> $GITHUB_ENV
         echo "::set-output name=QTCI_ARCH::${QTCI_ARCH}"
-        echo "::set-env name=WZ_VC_GENERATOR::${WZ_VC_GENERATOR}"
-        #echo "::set-env name=WZ_VC_TOOLCHAIN::${WZ_VC_TOOLCHAIN}"
-        echo "::set-env name=WZ_VISUAL_STUDIO_INSTALL_PATH::${WZ_VISUAL_STUDIO_INSTALL_PATH}"
-        echo "::set-env name=VCPKG_VISUAL_STUDIO_PATH::${VCPKG_VISUAL_STUDIO_PATH}"
-        echo "::set-env name=WZ_DISTRIBUTOR::${WZ_DISTRIBUTOR}"
+        echo "WZ_VC_GENERATOR=${WZ_VC_GENERATOR}" >> $GITHUB_ENV
+        #echo "WZ_VC_TOOLCHAIN=${WZ_VC_TOOLCHAIN}" >> $GITHUB_ENV
+        echo "WZ_VISUAL_STUDIO_INSTALL_PATH=${WZ_VISUAL_STUDIO_INSTALL_PATH}" >> $GITHUB_ENV
+        echo "VCPKG_VISUAL_STUDIO_PATH=${VCPKG_VISUAL_STUDIO_PATH}" >> $GITHUB_ENV
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
         echo "::set-output name=WZ_DEPLOY_RELEASE::${WZ_DEPLOY_RELEASE}"
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.7.2

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -40,11 +40,11 @@ jobs:
         if ($env:WZ_TARGET_ARCH -eq "x86") {
           $VCPKG_DEFAULT_TRIPLET = "x86-windows"
           $WZ_VC_TARGET_PLATFORMNAME = "Win32" # special case, map "x86" -> "Win32"
-          $QTCI_ARCH = "win32_msvc2017"
+          $QTCI_ARCH = "win32_msvc2019"
         }
         elseif ($env:WZ_TARGET_ARCH -eq "x64") {
           $VCPKG_DEFAULT_TRIPLET = "x64-windows"
-          $QTCI_ARCH = "win64_msvc2017_64"
+          $QTCI_ARCH = "win64_msvc2019_64"
         }
 
         # ------------------------------


### PR DESCRIPTION
Latest churn in CI:
- Update actions to use Environment Files instead of set-env
- Bump install-qt-action to 2.13.0
- Use Qt 5.15.2 for Mac OS and Windows