### PR TITLE
Deprecate WZM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # WMIT
 Warzone Model Import Tool
 
-Import and export .WZM, [.PIE](https://github.com/Warzone2100/warzone2100/blob/master/doc/PIE.md), and .OBJ files.
+Import and export [.PIE](https://github.com/Warzone2100/warzone2100/blob/master/doc/PIE.md), and .OBJ files.
+
+Also can import files in .WZM format.
+> Note: support for .WZM format is deprecated and will be removed in a future release. Please migrate your files into .PIE format.
 
 For use with: [Warzone 2100](https://github.com/Warzone2100/warzone2100)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,13 +84,7 @@ int main(int argc, char *argv[])
 		info.m_saveAsFile = argv[2];
 		if (!MainWindow::guessModelTypeFromFilename(info.m_saveAsFile, info.m_save_type))
 		{
-			std::cerr << "Could not guess save model type from filename. Only PIE3, WZM, and OBJ formats are supported!" << std::endl;
-			return 1;
-		}
-
-		if (info.m_save_type == WMIT_FT_WZM)
-		{
-			std::cerr << WMIT_WARN_DEPRECATED_WZM << std::endl;
+			std::cerr << "Could not guess save model type from filename. Only PIE and OBJ formats are supported!" << std::endl;
 			return 1;
 		}
 
@@ -99,11 +93,6 @@ int main(int argc, char *argv[])
 		{
 			printf("Could not load model\n");
 			return 1;
-		}
-
-		if (info.m_read_type == WMIT_FT_WZM)
-		{
-			std::cout << WMIT_WARN_DEPRECATED_WZM << std::endl;
 		}
 
 		info.defaultPieCapsIfNeeded();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 		printf("  <no parameters> (opens GUI application)\n");
 		printf("  --help (shows this message)\n");
 		printf("  [filename] (opens a file in GUI)\n");
-		printf("  [input] [output] (converts between formats wzm, pie and obj)\n");
+		printf("  [input] [output] (converts between formats PIE and OBJ. Deprecated WZM format is supported as input.)\n");
 		exit(0);
 	}
 
@@ -88,11 +88,22 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 
+		if (info.m_save_type == WMIT_FT_WZM)
+		{
+			std::cerr << WMIT_WARN_DEPRECATED_WZM << std::endl;
+			return 1;
+		}
+
 		std::cout << "Loading model..." << std::endl;
 		if (!MainWindow::loadModel(inname, model, info, true))
 		{
 			printf("Could not load model\n");
 			return 1;
+		}
+
+		if (info.m_read_type == WMIT_FT_WZM)
+		{
+			std::cout << WMIT_WARN_DEPRECATED_WZM << std::endl;
 		}
 
 		info.defaultPieCapsIfNeeded();

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -550,10 +550,12 @@ void MainWindow::actionSave()
 	if (m_modelinfo.m_currentFile.isEmpty())
 	{
 		actionSaveAs();
-		return;
 	}
-
-	saveModel(*m_model, m_modelinfo);
+	else if (!saveModel(*m_model, m_modelinfo))
+	{
+		QMessageBox::critical(this, "Save error",
+				      QString("Unable to save '%1'").arg(m_modelinfo.m_saveAsFile));
+	}
 }
 
 void MainWindow::PrependFileToRecentList(const QString& filename)
@@ -632,6 +634,7 @@ void MainWindow::actionSaveAs()
 		break;
 	case WMIT_FT_WZM:
 		std::cerr << WMIT_WARN_DEPRECATED_WZM << std::endl;
+		QMessageBox::critical(this, "Save error", WMIT_WARN_DEPRECATED_WZM);
 		return;
 	}
 
@@ -643,7 +646,11 @@ void MainWindow::actionSaveAs()
 	m_modelinfo = tmpModelinfo;
 	PrependFileToRecentList(m_modelinfo.m_saveAsFile);
 
-	saveModel(*m_model, m_modelinfo);
+	if (!saveModel(*m_model, m_modelinfo))
+	{
+		QMessageBox::critical(this, "Save error",
+		      QString("Unable to save as '%1'").arg(m_modelinfo.m_saveAsFile));
+	}
 }
 
 bool MainWindow::reloadShader(wz_shader_type_t type, bool user_shader, QString *errMessage)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -63,7 +63,7 @@ struct ModelInfo
 
 	void clear()
 	{
-		m_save_type = m_read_type = WMIT_FT_WZM;
+		m_save_type = m_read_type = WMIT_FT_PIE;
 		m_pieCaps.reset();
 		m_currentFile.clear();
 		m_saveAsFile.clear();

--- a/src/ui/aboutdialog.ui
+++ b/src/ui/aboutdialog.ui
@@ -24,7 +24,7 @@
    <item>
     <widget class="QLabel" name="lblText">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Warzone Model Import Tool&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Import and export &lt;a href=&quot;https://github.com/Warzone2100/warzone2100/blob/master/doc/PIE.md&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#3584e4;&quot;&gt;.PIE&lt;/span&gt;&lt;/a&gt;, .WZM and .OBJ files. For use with: &lt;a href=&quot;https://github.com/Warzone2100/warzone2100&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#3584e4;&quot;&gt;Warzone 2100&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Warzone Model Import Tool&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Import and export &lt;a href=&quot;https://github.com/Warzone2100/warzone2100/blob/master/doc/PIE.md&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#3584e4;&quot;&gt;.PIE&lt;/span&gt;&lt;/a&gt; and .OBJ files. For use with: &lt;a href=&quot;https://github.com/Warzone2100/warzone2100&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#3584e4;&quot;&gt;Warzone 2100&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/wmit.h
+++ b/src/wmit.h
@@ -28,4 +28,6 @@
 #define WMIT_IMAGES_BANNER ":/data/images/wmit_banner.png"
 #define WMIT_IMAGES_LOGO_64 ":/data/images/wmit_logo_64.png"
 
+#define WMIT_WARN_DEPRECATED_WZM "WARNING: support for .WZM format is deprecated and will be removed in a future release. Please migrate your files into .PIE format!"
+
 enum wmit_filetype_t { WMIT_FT_PIE = 0, WMIT_FT_PIE2, WMIT_FT_WZM, WMIT_FT_OBJ };


### PR DESCRIPTION
- Add deprecation notes into README file and CLI
- Print warning into stdout when loading WZM files
- Error on WZM export
- Remove WZM from About dialog

Closes #34 